### PR TITLE
FIX #24. Changed generics in interface of RendererBuilder.

### DIFF
--- a/renderers/src/main/java/com/pedrogomez/renderers/RendererBuilder.java
+++ b/renderers/src/main/java/com/pedrogomez/renderers/RendererBuilder.java
@@ -24,6 +24,8 @@ import com.pedrogomez.renderers.exception.NullLayoutInflaterException;
 import com.pedrogomez.renderers.exception.NullParentException;
 import com.pedrogomez.renderers.exception.NullPrototypeClassException;
 import com.pedrogomez.renderers.exception.PrototypeNotFoundException;
+
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -45,21 +47,21 @@ import java.util.Map;
  */
 public class RendererBuilder<T> {
 
-  private List<Renderer<T>> prototypes;
+  private List<Renderer<? extends T>> prototypes;
 
   private T content;
   private View convertView;
   private ViewGroup parent;
   private LayoutInflater layoutInflater;
   private Integer viewType;
-  private Map<Class<T>, Class<? extends Renderer>> binding;
+  private Map<Class<? extends T>, Class<? extends Renderer>> binding;
 
   /**
    * Initializes a RendererBuilder with an empty prototypes collection. Using this constructor some
    * binding configuration is needed.
    */
   public RendererBuilder() {
-    this(new LinkedList<Renderer<T>>());
+    this(new LinkedList<Renderer<? extends T>>());
   }
 
   /**
@@ -67,21 +69,21 @@ public class RendererBuilder<T> {
    * used will be always the same and the additional binding configuration wont be needed.
    */
   public RendererBuilder(Renderer<T> renderer) {
-    this(Collections.singletonList(renderer));
+    this(Collections.<Renderer<? extends T>>singletonList(renderer));
   }
 
   /**
    * Initializes a RendererBuilder with a list of prototypes. Using this constructor some
    * binding configuration is needed.
    */
-  public RendererBuilder(List<Renderer<T>> prototypes) {
+  public RendererBuilder(Collection<? extends Renderer<? extends T>> prototypes) {
     if (prototypes == null) {
       throw new NeedsPrototypesException(
           "RendererBuilder has to be created with a non null collection of"
               + "Collection<Renderer<T> to provide new or recycled Renderer instances");
     }
-    this.prototypes = prototypes;
-    this.binding = new HashMap<Class<T>, Class<? extends Renderer>>();
+    this.prototypes = new LinkedList<>(prototypes);
+    this.binding = new HashMap<Class<? extends T>, Class<? extends Renderer>>();
   }
 
   /**
@@ -89,8 +91,8 @@ public class RendererBuilder<T> {
    *
    * @return prototypes list.
    */
-  public final List<Renderer<T>> getPrototypes() {
-    return prototypes;
+  public final List<Renderer<? extends T>> getPrototypes() {
+    return Collections.unmodifiableList(prototypes);
   }
 
   /**
@@ -98,13 +100,13 @@ public class RendererBuilder<T> {
    *
    * @param prototypes to use by the builder in order to create Renderer instances.
    */
-  public final void setPrototypes(List<Renderer<T>> prototypes) {
+  public final void setPrototypes(Collection<? extends Renderer<? extends T>> prototypes) {
     if (prototypes == null) {
       throw new NeedsPrototypesException(
           "RendererBuilder has to be created with a non null collection of"
               + "Collection<Renderer<T> to provide new or recycled Renderer instances");
     }
-    this.prototypes = prototypes;
+    this.prototypes = new LinkedList<>(prototypes);
   }
 
   /**
@@ -113,7 +115,7 @@ public class RendererBuilder<T> {
    * @param prototypes to use by the builder in order to create Renderer instances.
    * @return the current RendererBuilder instance.
    */
-  public RendererBuilder<T> withPrototypes(List<Renderer<T>> prototypes) {
+  public RendererBuilder<T> withPrototypes(Collection<? extends Renderer<? extends T>> prototypes) {
     if (prototypes == null) {
       throw new NeedsPrototypesException(
           "RendererBuilder has to be created with a non null collection of"
@@ -129,7 +131,7 @@ public class RendererBuilder<T> {
    * @param renderer to use as prototype.
    * @return the current RendererBuilder instance.
    */
-  public RendererBuilder<T> withPrototype(Renderer<T> renderer) {
+  public RendererBuilder<T> withPrototype(Renderer<? extends T> renderer) {
     if (renderer == null) {
       throw new NeedsPrototypesException(
           "RendererBuilder can't use a null Renderer<T> instance as prototype");
@@ -145,7 +147,7 @@ public class RendererBuilder<T> {
    * @param prototype used as Renderer.
    * @return the current RendererBuilder instance.
    */
-  public RendererBuilder<T> bind(Class<T> clazz, Renderer<T> prototype) {
+  public <G extends T> RendererBuilder<T> bind(Class<G> clazz, Renderer<? extends G> prototype) {
     if (clazz == null || prototype == null) {
       throw new IllegalArgumentException(
           "The binding RecyclerView binding can't be configured using null instances");
@@ -155,7 +157,7 @@ public class RendererBuilder<T> {
     return this;
   }
 
-  public RendererBuilder<T> bind(Class<T> clazz, Class<? extends Renderer> prototypeClass) {
+  public <G extends T> RendererBuilder<T> bind(Class<G> clazz, Class<? extends Renderer<? extends G>> prototypeClass) {
     if (clazz == null || prototypeClass == null) {
       throw new IllegalArgumentException(
           "The binding RecyclerView binding can't be configured using null instances");

--- a/renderers/src/test/java/com/pedrogomez/renderers/IntegerRenderer.java
+++ b/renderers/src/test/java/com/pedrogomez/renderers/IntegerRenderer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2014 Pedro Vicente Gómez Sánchez.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.pedrogomez.renderers;
 
 import android.view.LayoutInflater;
@@ -6,8 +21,6 @@ import android.view.ViewGroup;
 
 /**
  * Renderer created only for testing purposes.
- *
- * @author Rostyslav Roshak.
  */
 public class IntegerRenderer extends Renderer<Integer> {
 

--- a/renderers/src/test/java/com/pedrogomez/renderers/IntegerRenderer.java
+++ b/renderers/src/test/java/com/pedrogomez/renderers/IntegerRenderer.java
@@ -21,6 +21,8 @@ import android.view.ViewGroup;
 
 /**
  * Renderer created only for testing purposes.
+ *
+ * @author Rostyslav Roshak.
  */
 public class IntegerRenderer extends Renderer<Integer> {
 

--- a/renderers/src/test/java/com/pedrogomez/renderers/IntegerRenderer.java
+++ b/renderers/src/test/java/com/pedrogomez/renderers/IntegerRenderer.java
@@ -1,0 +1,35 @@
+package com.pedrogomez.renderers;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+/**
+ * Renderer created only for testing purposes.
+ *
+ * @author Rostyslav Roshak.
+ */
+public class IntegerRenderer extends Renderer<Integer> {
+
+  private View view;
+
+  @Override protected void setUpView(View rootView) {
+
+  }
+
+  @Override protected void hookListeners(View rootView) {
+
+  }
+
+  @Override protected View inflate(LayoutInflater inflater, ViewGroup parent) {
+    return view;
+  }
+
+  @Override public void render() {
+
+  }
+
+  public void setView(View view) {
+    this.view = view;
+  }
+}

--- a/renderers/src/test/java/com/pedrogomez/renderers/RendererBuilderTest.java
+++ b/renderers/src/test/java/com/pedrogomez/renderers/RendererBuilderTest.java
@@ -8,6 +8,9 @@ import com.pedrogomez.renderers.exception.NullContentException;
 import com.pedrogomez.renderers.exception.NullLayoutInflaterException;
 import com.pedrogomez.renderers.exception.NullParentException;
 import com.pedrogomez.renderers.exception.NullPrototypeClassException;
+
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import org.junit.Before;
@@ -139,12 +142,55 @@ public class RendererBuilderTest {
     assertEquals(ObjectRenderer.class, rendererBuilder.getPrototypeClass(new Object()));
   }
 
+  @Test public void shouldAddDescendantPrototypeAndConfigureRendererBinding() {
+    RendererBuilder<Object> rendererBuilder = new RendererBuilder<Object>();
+
+    rendererBuilder.bind(String.class, new StringRenderer());
+    rendererBuilder.bind(Integer.class, new IntegerRenderer());
+
+
+    assertEquals(StringRenderer.class, rendererBuilder.getPrototypeClass(""));
+    assertEquals(IntegerRenderer.class, rendererBuilder.getPrototypeClass(0));
+  }
+
   @Test public void shouldAddPrototypeAndConfigureBindingByClass() {
     RendererBuilder<Object> rendererBuilder = new RendererBuilder<Object>();
 
     rendererBuilder.withPrototype(new ObjectRenderer()).bind(Object.class, ObjectRenderer.class);
 
     assertEquals(ObjectRenderer.class, rendererBuilder.getPrototypeClass(new Object()));
+  }
+
+  @Test public void shouldAddDescendantPrototypesAndConfigureBindingByClass() {
+    RendererBuilder<Object> rendererBuilder = new RendererBuilder<Object>();
+
+    rendererBuilder
+            .withPrototype(new StringRenderer()).bind(String.class, StringRenderer.class)
+            .withPrototype(new IntegerRenderer()).bind(Integer.class, IntegerRenderer.class);
+
+    assertEquals(StringRenderer.class, rendererBuilder.getPrototypeClass(""));
+    assertEquals(IntegerRenderer.class, rendererBuilder.getPrototypeClass(0));
+  }
+
+  @Test public void shouldAddDescendantPrototypesBySetterAndConfigureBindingByClass() {
+    RendererBuilder<Object> rendererBuilder = new RendererBuilder<Object>();
+
+    rendererBuilder.setPrototypes(Arrays.asList(new StringRenderer(), new IntegerRenderer()));
+    rendererBuilder.bind(String.class, StringRenderer.class);
+    rendererBuilder.bind(Integer.class, IntegerRenderer.class);
+
+    assertEquals(StringRenderer.class, rendererBuilder.getPrototypeClass(""));
+    assertEquals(IntegerRenderer.class, rendererBuilder.getPrototypeClass(0));
+  }
+
+  @Test public void shouldAddDescendantPrototypesByConstructionAndConfigureBindingByClass() {
+    RendererBuilder<Object> rendererBuilder = new RendererBuilder<Object>(Arrays.asList(new StringRenderer(), new IntegerRenderer()));
+
+    rendererBuilder.bind(String.class, StringRenderer.class);
+    rendererBuilder.bind(Integer.class, IntegerRenderer.class);
+
+    assertEquals(StringRenderer.class, rendererBuilder.getPrototypeClass(""));
+    assertEquals(IntegerRenderer.class, rendererBuilder.getPrototypeClass(0));
   }
 
   @Test public void shouldAddPrototyeAndconfigureBindingOnConstruction() {

--- a/renderers/src/test/java/com/pedrogomez/renderers/RendererBuilderTest.java
+++ b/renderers/src/test/java/com/pedrogomez/renderers/RendererBuilderTest.java
@@ -10,7 +10,6 @@ import com.pedrogomez.renderers.exception.NullParentException;
 import com.pedrogomez.renderers.exception.NullPrototypeClassException;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import org.junit.Before;
@@ -184,7 +183,8 @@ public class RendererBuilderTest {
   }
 
   @Test public void shouldAddDescendantPrototypesByConstructionAndConfigureBindingByClass() {
-    RendererBuilder<Object> rendererBuilder = new RendererBuilder<Object>(Arrays.asList(new StringRenderer(), new IntegerRenderer()));
+    RendererBuilder<Object> rendererBuilder =
+            new RendererBuilder<Object>(Arrays.asList(new StringRenderer(), new IntegerRenderer()));
 
     rendererBuilder.bind(String.class, StringRenderer.class);
     rendererBuilder.bind(Integer.class, IntegerRenderer.class);

--- a/renderers/src/test/java/com/pedrogomez/renderers/StringRenderer.java
+++ b/renderers/src/test/java/com/pedrogomez/renderers/StringRenderer.java
@@ -1,0 +1,35 @@
+package com.pedrogomez.renderers;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+/**
+ * Renderer created only for testing purposes.
+ *
+ * @author Rostyslav Roshak.
+ */
+public class StringRenderer extends Renderer<String> {
+
+  private View view;
+
+  @Override protected void setUpView(View rootView) {
+
+  }
+
+  @Override protected void hookListeners(View rootView) {
+
+  }
+
+  @Override protected View inflate(LayoutInflater inflater, ViewGroup parent) {
+    return view;
+  }
+
+  @Override public void render() {
+
+  }
+
+  public void setView(View view) {
+    this.view = view;
+  }
+}

--- a/renderers/src/test/java/com/pedrogomez/renderers/StringRenderer.java
+++ b/renderers/src/test/java/com/pedrogomez/renderers/StringRenderer.java
@@ -21,6 +21,8 @@ import android.view.ViewGroup;
 
 /**
  * Renderer created only for testing purposes.
+ *
+ * @author Rostyslav Roshak.
  */
 public class StringRenderer extends Renderer<String> {
 

--- a/renderers/src/test/java/com/pedrogomez/renderers/StringRenderer.java
+++ b/renderers/src/test/java/com/pedrogomez/renderers/StringRenderer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2014 Pedro Vicente Gómez Sánchez.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.pedrogomez.renderers;
 
 import android.view.LayoutInflater;
@@ -6,8 +21,6 @@ import android.view.ViewGroup;
 
 /**
  * Renderer created only for testing purposes.
- *
- * @author Rostyslav Roshak.
  */
 public class StringRenderer extends Renderer<String> {
 


### PR DESCRIPTION
Changed RendererBuilder generics for supporting descendants classes to FIX #24.

E.g. In case when B, C extends A. This change allows to create `RendererBuilder<A>`
And bind rendering C objects using `Renderer<C>` and B objects to render with `Renderer<B>`.

Also this change improves encapsulation.

Changed constructor to public `RendererBuilder(Collection<? extends Renderer<? extends T>> prototypes)` that allows to use descendants.
e.g. When we have class A that extends B, we can use for creating `RendererBuilder<B>` collection that contains `Renderer<A>` and `Renderer<B>`. And bindings will configure what renderer should be used for what model class.

Added copy of collection to constructor for better encapsulation.

`getPrototypes` added Collections.unmodifiableList for better encapsulation.

public final void `setPrototypes(Collection<? extends Renderer<? extends T>> prototypes)`
and `RendererBuilder<T> withPrototypes(Collection<? extends Renderer<? extends T>> prototypes)` changed to received descendants renderers.