### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ RendererBuilder<Video> rendererBuilder = new RendererBuilder<Video>(renderer);
 If you need to map different object instances to different ``Renderer`` implementations you can use ``RendererBuilder.bind`` methods:
 
 ```java
-RendererBuilder<Video> rendererBuilder = new RendererBuilder<>()
+RendererBuilder<Video> rendererBuilder = new RendererBuilder<Video>()
         .bind(Video.class, new LikeVideoRenderer());
 ```
 


### PR DESCRIPTION
Diamonds do not work if you use an inline definition. 
RendererBuilder<Video> rendererBuilder = new RendererBuilder<>();
        renderBuilder.bind(Video.class, new LikeVideoRenderer());

this works or this.

RendererBuilder<Video> rendererBuilder = new RendererBuilder<Video>().
        bind(Video.class, new LikeVideoRenderer());

choose as you want.