### PR TITLE
Added Collection setter in RVRendererAdapter

### DIFF
--- a/renderers/src/main/java/com/pedrogomez/renderers/RVRendererAdapter.java
+++ b/renderers/src/main/java/com/pedrogomez/renderers/RVRendererAdapter.java
@@ -63,7 +63,7 @@ public class RVRendererAdapter<T> extends RecyclerView.Adapter<RendererViewHolde
 
   public void setCollection(AdapteeCollection<T> collection) {
       if (collection == null) {
-          throw new IllegalArgumentException("Collection must be not null");
+          throw new IllegalArgumentException("The AdapteeCollection configured can't be null");
       }
 
       this.collection = collection;

--- a/renderers/src/main/java/com/pedrogomez/renderers/RVRendererAdapter.java
+++ b/renderers/src/main/java/com/pedrogomez/renderers/RVRendererAdapter.java
@@ -39,14 +39,13 @@ public class RVRendererAdapter<T> extends RecyclerView.Adapter<RendererViewHolde
   private final RendererBuilder<T> rendererBuilder;
   private AdapteeCollection<T> collection;
 
+  public RVRendererAdapter(RendererBuilder<T> rendererBuilder) {
+    this(rendererBuilder, new ListAdapteeCollection<T>());
+  }
+
   public RVRendererAdapter(RendererBuilder<T> rendererBuilder, AdapteeCollection<T> collection) {
     this.rendererBuilder = rendererBuilder;
     this.collection = collection;
-  }
-
-  public RVRendererAdapter(RendererBuilder<T> rendererBuilder) {
-        this.rendererBuilder = rendererBuilder;
-        this.collection = new ListAdapteeCollection<T>();
   }
 
   @Override public int getItemCount() {

--- a/renderers/src/main/java/com/pedrogomez/renderers/RVRendererAdapter.java
+++ b/renderers/src/main/java/com/pedrogomez/renderers/RVRendererAdapter.java
@@ -37,11 +37,16 @@ import java.util.Collection;
 public class RVRendererAdapter<T> extends RecyclerView.Adapter<RendererViewHolder> {
 
   private final RendererBuilder<T> rendererBuilder;
-  private final AdapteeCollection<T> collection;
+  private AdapteeCollection<T> collection;
 
   public RVRendererAdapter(RendererBuilder<T> rendererBuilder, AdapteeCollection<T> collection) {
     this.rendererBuilder = rendererBuilder;
     this.collection = collection;
+  }
+
+  public RVRendererAdapter(RendererBuilder<T> rendererBuilder) {
+        this.rendererBuilder = rendererBuilder;
+        this.collection = new ListAdapteeCollection<T>();
   }
 
   @Override public int getItemCount() {
@@ -56,7 +61,15 @@ public class RVRendererAdapter<T> extends RecyclerView.Adapter<RendererViewHolde
     return position;
   }
 
-  /**
+  public void setCollection(AdapteeCollection<T> collection) {
+      if (collection == null) {
+          throw new IllegalArgumentException("Collection must be not null");
+      }
+
+      this.collection = collection;
+  }
+
+    /**
    * Indicate to the RecyclerView the type of Renderer used to one position using a numeric value.
    *
    * @param position to analyze.

--- a/renderers/src/main/java/com/pedrogomez/renderers/RendererAdapter.java
+++ b/renderers/src/main/java/com/pedrogomez/renderers/RendererAdapter.java
@@ -40,11 +40,11 @@ public class RendererAdapter<T> extends BaseAdapter {
   private final RendererBuilder<T> rendererBuilder;
   private AdapteeCollection<T> collection;
 
-  public RendererAdapter(RendererBuilder rendererBuilder) {
+  public RendererAdapter(RendererBuilder<T> rendererBuilder) {
     this(rendererBuilder, new ListAdapteeCollection<T>());
   }
 
-  public RendererAdapter(RendererBuilder rendererBuilder, AdapteeCollection<T> collection) {
+  public RendererAdapter(RendererBuilder<T> rendererBuilder, AdapteeCollection<T> collection) {
     this.rendererBuilder = rendererBuilder;
     this.collection = collection;
   }

--- a/renderers/src/main/java/com/pedrogomez/renderers/RendererAdapter.java
+++ b/renderers/src/main/java/com/pedrogomez/renderers/RendererAdapter.java
@@ -38,7 +38,7 @@ import java.util.Collection;
 public class RendererAdapter<T> extends BaseAdapter {
 
   private final RendererBuilder<T> rendererBuilder;
-  private final AdapteeCollection<T> collection;
+  private AdapteeCollection<T> collection;
 
   public RendererAdapter(RendererBuilder rendererBuilder) {
     this(rendererBuilder, new ListAdapteeCollection<T>());
@@ -59,6 +59,14 @@ public class RendererAdapter<T> extends BaseAdapter {
 
   @Override public long getItemId(int position) {
     return position;
+  }
+
+  public void setCollection(AdapteeCollection<T> collection) {
+    if (collection == null) {
+      throw new IllegalArgumentException("The AdapteeCollection configured can't be null");
+    }
+
+    this.collection = collection;
   }
 
   /**

--- a/renderers/src/test/java/com/pedrogomez/renderers/RVRendererAdapterTest.java
+++ b/renderers/src/test/java/com/pedrogomez/renderers/RVRendererAdapterTest.java
@@ -33,7 +33,9 @@ import java.util.LinkedList;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.notNull;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Test class created to check the correct behaviour of RVRendererAdapter.

--- a/renderers/src/test/java/com/pedrogomez/renderers/RVRendererAdapterTest.java
+++ b/renderers/src/test/java/com/pedrogomez/renderers/RVRendererAdapterTest.java
@@ -176,7 +176,6 @@ import static org.mockito.Mockito.*;
     assertEquals(0, adapter.getItemCount());
   }
 
-
   @Test(expected = IllegalArgumentException.class)
   public void shouldThrowExceptionWhenSetNullCollection() {
     RVRendererAdapter<Object> adapter = new RVRendererAdapter<Object>(mockedRendererBuilder);

--- a/renderers/src/test/java/com/pedrogomez/renderers/RVRendererAdapterTest.java
+++ b/renderers/src/test/java/com/pedrogomez/renderers/RVRendererAdapterTest.java
@@ -34,7 +34,9 @@ import java.util.LinkedList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.notNull;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Test class created to check the correct behaviour of RVRendererAdapter.

--- a/renderers/src/test/java/com/pedrogomez/renderers/RVRendererAdapterTest.java
+++ b/renderers/src/test/java/com/pedrogomez/renderers/RVRendererAdapterTest.java
@@ -32,11 +32,8 @@ import java.util.Collection;
 import java.util.LinkedList;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.notNull;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 /**
  * Test class created to check the correct behaviour of RVRendererAdapter.
@@ -173,10 +170,10 @@ import static org.mockito.Mockito.when;
     assertEquals(mockedCollection, adapter.getCollection());
   }
 
-  @Test public void shouldBeAdapteeCollectionNotNullWhenCreateOnlyWithRendererBuilder() {
+  @Test public void shouldBeEmptyWhenItsCreatedWithJustARendererBuilder() {
     RVRendererAdapter<Object> adapter = new RVRendererAdapter<Object>(mockedRendererBuilder);
 
-    assertNotNull(adapter.getCollection());
+    assertEquals(0, adapter.getItemCount());
   }
 
 

--- a/renderers/src/test/java/com/pedrogomez/renderers/RVRendererAdapterTest.java
+++ b/renderers/src/test/java/com/pedrogomez/renderers/RVRendererAdapterTest.java
@@ -19,8 +19,6 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import com.pedrogomez.renderers.exception.NullRendererBuiltException;
-import java.util.Collection;
-import java.util.LinkedList;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -30,11 +28,13 @@ import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
+import java.util.Collection;
+import java.util.LinkedList;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.notNull;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 /**
  * Test class created to check the correct behaviour of RVRendererAdapter.
@@ -161,6 +161,28 @@ import static org.mockito.Mockito.when;
     adapter.onBindViewHolder(mockedRendererViewHolder, ANY_POSITION);
 
     verify(mockedRenderer).render();
+  }
+
+  @Test public void shouldSetAdapteeCollection() throws Exception {
+    RVRendererAdapter<Object> adapter = new RVRendererAdapter<Object>(mockedRendererBuilder);
+
+    adapter.setCollection(mockedCollection);
+
+    assertEquals(mockedCollection, adapter.getCollection());
+  }
+
+  @Test public void shouldBeAdapteeCollectionNotNullWhenCreateOnlyWithRendererBuilder() {
+    RVRendererAdapter<Object> adapter = new RVRendererAdapter<Object>(mockedRendererBuilder);
+
+    assertNotNull(adapter.getCollection());
+  }
+
+
+  @Test(expected = IllegalArgumentException.class)
+  public void shouldThrowExceptionWhenSetNullCollection() {
+    RVRendererAdapter<Object> adapter = new RVRendererAdapter<Object>(mockedRendererBuilder);
+
+    adapter.setCollection(null);
   }
 
   private void initializeMocks() {

--- a/renderers/src/test/java/com/pedrogomez/renderers/RendererAdapterTest.java
+++ b/renderers/src/test/java/com/pedrogomez/renderers/RendererAdapterTest.java
@@ -4,8 +4,6 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import com.pedrogomez.renderers.exception.NullRendererBuiltException;
-import java.util.Collection;
-import java.util.LinkedList;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -15,11 +13,12 @@ import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
+import java.util.Collection;
+import java.util.LinkedList;
+
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.notNull;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 /**
  * Test class created to check the correct behaviour of RendererAdapter.
@@ -152,6 +151,28 @@ import static org.mockito.Mockito.when;
     rendererAdapter.clear();
 
     verify(mockedCollection).clear();
+  }
+
+  @Test public void shouldSetAdapteeCollection() throws Exception {
+    RendererAdapter<Object> adapter = new RendererAdapter<Object>(mockedRendererBuilder);
+
+    adapter.setCollection(mockedCollection);
+
+    assertEquals(mockedCollection, adapter.getCollection());
+  }
+
+  @Test public void shouldBeEmptyWhenItsCreatedWithJustARendererBuilder() {
+    RendererAdapter<Object> adapter = new RendererAdapter<Object>(mockedRendererBuilder);
+
+    assertEquals(0, adapter.getCount());
+  }
+
+
+  @Test(expected = IllegalArgumentException.class)
+  public void shouldThrowExceptionWhenSetNullCollection() {
+    RendererAdapter<Object> adapter = new RendererAdapter<Object>(mockedRendererBuilder);
+
+    adapter.setCollection(null);
   }
 
   private void initializeMocks() {

--- a/renderers/src/test/java/com/pedrogomez/renderers/RendererAdapterTest.java
+++ b/renderers/src/test/java/com/pedrogomez/renderers/RendererAdapterTest.java
@@ -18,7 +18,9 @@ import java.util.LinkedList;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.notNull;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Test class created to check the correct behaviour of RendererAdapter.


### PR DESCRIPTION
In some occasions when it creates a `AdapteeCollection` for `RVRendererAdapter` needs  a `RecyclerView.Adapter`.

- **Problem** example using `package android.support.v7.util.SortedList`: 

```java
public MyAdapteeCollectionConstructor(RecyclerView.Adapter ANY_ADAPTER) {
    
    this.messageList = new SortedList<Message>(Message.class, new SortedListAdapterCallback<Message>(ANY_ADAPTER) {
            @Override
            public int compare(Message o1, Message o2) {
                return o1.compareTo(o2);
            }

            @Override
            public boolean areContentsTheSame(Message oldItem, Message newItem) {
                return oldItem.equals(newItem);
            }

            @Override
            public boolean areItemsTheSame(Message item1, Message item2) {
                return item1.getId().equals(item2.getId());
            }
        });
}
```

RVRendererAdapter creation:

```java
adapter = new RVRendererAdapter<Message>(new MessageRenderBuilder(), new MyAdapteeCollection(WHAT ADAPTER?));
```

--------------

- **Solution with actual `Renderers` version** for this example:

```java
public MyAdapteeCollectionConstructor() {
    //init default messageList
}

...

 public void initCollection(RecyclerView.Adapter adapter) {
        messageList = new SortedList<Message>(Message.class, new SortedListAdapterCallback<Message>(adapter) {
            @Override
            public int compare(Message o1, Message o2) {
                return o1.compareTo(o2);
            }

            @Override
            public boolean areContentsTheSame(Message oldItem, Message newItem) {
                return oldItem.equals(newItem);
            }

            @Override
            public boolean areItemsTheSame(Message item1, Message item2) {
                return item1.getId().equals(item2.getId());
            }
        });
    }
```

RVRendererAdapter creation:

```java
adapteeCollection = new MyAdapteeCollection();
adapter = new RVRendererAdapter<Message>(new MessageRenderBuilder(), adapteeCollection);
adapteeCollection.initCollection(adapter);
```

--------------

- **Solution** with for this example (_better solution?_):

```java
public MyAdapteeCollectionConstructor(RecyclerView.Adapter ANY_ADAPTER) { ... }
```

RVRendererAdapter creation:

```java
adapter = new RVRendererAdapter<Message>(new MessageRenderBuilder());
adapter.setCollection(new MyAdapteeCollection(adapter));
```