### PR TITLE
Providing multi-select to RVAdapter

### DIFF
--- a/renderers/src/main/java/com/pedrogomez/renderers/MultiSelector.java
+++ b/renderers/src/main/java/com/pedrogomez/renderers/MultiSelector.java
@@ -11,12 +11,20 @@ import java.util.Set;
 public class MultiSelector<T> implements Selector<T> {
 
   private final Set<T> selectedItems = new HashSet<>();
+  private boolean isSelectable = false;
 
   @Override public void setSelectable(boolean isSelectable) {
-
+    this.isSelectable = isSelectable;
+    if (!isSelectable) {
+      selectedItems.clear();
+    }
   }
 
   @Override public void setSelected(boolean isSelected, T item) {
+    if (!isSelectable) {
+      return;
+    }
+
     if (isSelected) {
       selectedItems.add(item);
     } else {
@@ -26,5 +34,10 @@ public class MultiSelector<T> implements Selector<T> {
 
   @Override public boolean isSelected(T item) {
     return selectedItems.contains(item);
+  }
+
+  @Override
+  public Set<T> getSelectedItems() {
+    return selectedItems;
   }
 }

--- a/renderers/src/main/java/com/pedrogomez/renderers/MultiSelector.java
+++ b/renderers/src/main/java/com/pedrogomez/renderers/MultiSelector.java
@@ -1,0 +1,21 @@
+package com.pedrogomez.renderers;
+
+/**
+ * TBD
+ *
+ * @author Arturo Gutiérrez Díaz-Guerra.
+ */
+public class MultiSelector<T> implements Selector<T> {
+
+  @Override public void setSelectable(boolean isSelectable) {
+
+  }
+
+  @Override public void setSelected(boolean isSelected, T item) {
+
+  }
+
+  @Override public boolean isSelected(T content) {
+    return false;
+  }
+}

--- a/renderers/src/main/java/com/pedrogomez/renderers/MultiSelector.java
+++ b/renderers/src/main/java/com/pedrogomez/renderers/MultiSelector.java
@@ -20,6 +20,10 @@ class MultiSelector<T> implements Selector<T> {
 
   private boolean isSelectable = false;
 
+  @Override public boolean isSelectable() {
+    return isSelectable;
+  }
+
   @Override public void setSelectable(boolean isSelectable) {
     this.isSelectable = isSelectable;
     if (!isSelectable) {

--- a/renderers/src/main/java/com/pedrogomez/renderers/MultiSelector.java
+++ b/renderers/src/main/java/com/pedrogomez/renderers/MultiSelector.java
@@ -1,43 +1,92 @@
 package com.pedrogomez.renderers;
 
+import android.support.annotation.Nullable;
+
+import java.lang.ref.WeakReference;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 /**
- * TBD
+ * Implementation of selector to give support for multi-selection. It tracks the selected
+ * items and refresh the corresponding renderers when it's necessary.
  *
  * @author Arturo Gutiérrez Díaz-Guerra.
  */
-public class MultiSelector<T> implements Selector<T> {
+class MultiSelector<T> implements Selector<T> {
 
-  private final Set<T> selectedItems = new HashSet<>();
+  private final Set<String> selectedItemIds = new HashSet<>();
+  private final Map<String, WeakReference<Renderer<T>>> trackedRenderers = new HashMap<>();
+
   private boolean isSelectable = false;
 
   @Override public void setSelectable(boolean isSelectable) {
     this.isSelectable = isSelectable;
     if (!isSelectable) {
-      selectedItems.clear();
+      selectedItemIds.clear();
+      refreshAllRenderers();
     }
   }
 
-  @Override public void setSelected(boolean isSelected, T item) {
+  @Override public void setSelected(boolean isSelected, String itemId) {
     if (!isSelectable) {
       return;
     }
 
     if (isSelected) {
-      selectedItems.add(item);
+      selectedItemIds.add(itemId);
     } else {
-      selectedItems.remove(item);
+      selectedItemIds.remove(itemId);
     }
-  }
 
-  @Override public boolean isSelected(T item) {
-    return selectedItems.contains(item);
+    refreshPosition(itemId);
   }
 
   @Override
-  public Set<T> getSelectedItems() {
-    return selectedItems;
+  public void onBindRenderer(Renderer<T> renderer) {
+    trackedRenderers.put(renderer.getItemId(), new WeakReference<>(renderer));
+  }
+
+  @Override public boolean isSelected(String itemId) {
+    return selectedItemIds.contains(itemId);
+  }
+
+  @Override
+  public Set<String> getSelectedItemIds() {
+    return selectedItemIds;
+  }
+
+  private void refreshPosition(String itemId) {
+    Renderer<T> renderer = getRendererForItemId(itemId);
+    if (renderer != null) {
+      renderer.render();
+    }
+  }
+
+  private void refreshAllRenderers() {
+    for(WeakReference<Renderer<T>> weakReference : trackedRenderers.values()) {
+      Renderer<T> renderer = weakReference.get();
+      if (renderer != null) {
+        refreshRenderer(renderer);
+      }
+    }
+  }
+
+  private void refreshRenderer(Renderer<T> renderer) {
+    renderer.render();
+  }
+
+  @Nullable private Renderer<T> getRendererForItemId(String itemId) {
+    WeakReference<Renderer<T>> weakReference = trackedRenderers.get(itemId);
+    Renderer<T> renderer = weakReference.get();
+    if (renderer != null) {
+      String rendererItemId = renderer.getItemId();
+      if (itemId.equals(rendererItemId)) {
+        return renderer;
+      }
+      trackedRenderers.remove(itemId);
+    }
+    return null;
   }
 }

--- a/renderers/src/main/java/com/pedrogomez/renderers/MultiSelector.java
+++ b/renderers/src/main/java/com/pedrogomez/renderers/MultiSelector.java
@@ -3,9 +3,7 @@ package com.pedrogomez.renderers;
 import android.support.annotation.Nullable;
 import java.lang.ref.WeakReference;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * Implementation of selector to give support for multi-selection. It tracks the selected
@@ -15,7 +13,7 @@ import java.util.Set;
  */
 class MultiSelector<T> implements Selector<T> {
 
-  private final Set<String> selectedItemIds = new HashSet<>();
+  private final Map<String, T> selectedItems = new HashMap<>();
   private final Map<String, WeakReference<Renderer<T>>> trackedRenderers = new HashMap<>();
 
   private boolean isSelectable = false;
@@ -27,20 +25,20 @@ class MultiSelector<T> implements Selector<T> {
   @Override public void setSelectable(boolean isSelectable) {
     this.isSelectable = isSelectable;
     if (!isSelectable) {
-      selectedItemIds.clear();
+      selectedItems.clear();
       refreshAllRenderers();
     }
   }
 
-  @Override public void setSelected(boolean isSelected, String itemId) {
+  @Override public void setSelected(boolean isSelected, String itemId, T item) {
     if (!isSelectable) {
       return;
     }
 
     if (isSelected) {
-      selectedItemIds.add(itemId);
+      selectedItems.put(itemId, item);
     } else {
-      selectedItemIds.remove(itemId);
+      selectedItems.remove(itemId);
     }
 
     refreshPosition(itemId);
@@ -51,11 +49,11 @@ class MultiSelector<T> implements Selector<T> {
   }
 
   @Override public boolean isSelected(String itemId) {
-    return selectedItemIds.contains(itemId);
+    return selectedItems.containsKey(itemId);
   }
 
-  @Override public Set<String> getSelectedItemIds() {
-    return selectedItemIds;
+  @Override public Map<String, T> getSelectedItems() {
+    return selectedItems;
   }
 
   private void refreshPosition(String itemId) {

--- a/renderers/src/main/java/com/pedrogomez/renderers/MultiSelector.java
+++ b/renderers/src/main/java/com/pedrogomez/renderers/MultiSelector.java
@@ -80,6 +80,9 @@ class MultiSelector<T> implements Selector<T> {
 
   @Nullable private Renderer<T> getRendererForItemId(String itemId) {
     WeakReference<Renderer<T>> weakReference = trackedRenderers.get(itemId);
+    if (weakReference == null) {
+      return null;
+    }
     Renderer<T> renderer = weakReference.get();
     if (renderer != null) {
       String rendererItemId = renderer.getItemId();

--- a/renderers/src/main/java/com/pedrogomez/renderers/MultiSelector.java
+++ b/renderers/src/main/java/com/pedrogomez/renderers/MultiSelector.java
@@ -1,5 +1,8 @@
 package com.pedrogomez.renderers;
 
+import java.util.HashSet;
+import java.util.Set;
+
 /**
  * TBD
  *
@@ -7,15 +10,21 @@ package com.pedrogomez.renderers;
  */
 public class MultiSelector<T> implements Selector<T> {
 
+  private final Set<T> selectedItems = new HashSet<>();
+
   @Override public void setSelectable(boolean isSelectable) {
 
   }
 
   @Override public void setSelected(boolean isSelected, T item) {
-
+    if (isSelected) {
+      selectedItems.add(item);
+    } else {
+      selectedItems.remove(item);
+    }
   }
 
-  @Override public boolean isSelected(T content) {
-    return false;
+  @Override public boolean isSelected(T item) {
+    return selectedItems.contains(item);
   }
 }

--- a/renderers/src/main/java/com/pedrogomez/renderers/MultiSelector.java
+++ b/renderers/src/main/java/com/pedrogomez/renderers/MultiSelector.java
@@ -1,7 +1,6 @@
 package com.pedrogomez.renderers;
 
 import android.support.annotation.Nullable;
-
 import java.lang.ref.WeakReference;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -43,8 +42,7 @@ class MultiSelector<T> implements Selector<T> {
     refreshPosition(itemId);
   }
 
-  @Override
-  public void onBindRenderer(Renderer<T> renderer) {
+  @Override public void onBindRenderer(Renderer<T> renderer) {
     trackedRenderers.put(renderer.getItemId(), new WeakReference<>(renderer));
   }
 
@@ -52,8 +50,7 @@ class MultiSelector<T> implements Selector<T> {
     return selectedItemIds.contains(itemId);
   }
 
-  @Override
-  public Set<String> getSelectedItemIds() {
+  @Override public Set<String> getSelectedItemIds() {
     return selectedItemIds;
   }
 
@@ -65,7 +62,7 @@ class MultiSelector<T> implements Selector<T> {
   }
 
   private void refreshAllRenderers() {
-    for(WeakReference<Renderer<T>> weakReference : trackedRenderers.values()) {
+    for (WeakReference<Renderer<T>> weakReference : trackedRenderers.values()) {
       Renderer<T> renderer = weakReference.get();
       if (renderer != null) {
         refreshRenderer(renderer);

--- a/renderers/src/main/java/com/pedrogomez/renderers/NoneSelector.java
+++ b/renderers/src/main/java/com/pedrogomez/renderers/NoneSelector.java
@@ -1,7 +1,7 @@
 package com.pedrogomez.renderers;
 
 import java.util.Collections;
-import java.util.Set;
+import java.util.Map;
 
 /**
  * None selector implementation. Used in the ListView Renderer implementation because ListView
@@ -19,7 +19,7 @@ class NoneSelector<T> implements Selector<T> {
     // Nothing
   }
 
-  @Override public void setSelected(boolean isSelected, String itemId) {
+  @Override public void setSelected(boolean isSelected, String itemId, T item) {
     // Nothing
   }
 
@@ -33,7 +33,7 @@ class NoneSelector<T> implements Selector<T> {
   }
 
   @Override
-  public Set<String> getSelectedItemIds() {
-    return Collections.emptySet();
+  public Map<String, T> getSelectedItems() {
+    return Collections.emptyMap();
   }
 }

--- a/renderers/src/main/java/com/pedrogomez/renderers/NoneSelector.java
+++ b/renderers/src/main/java/com/pedrogomez/renderers/NoneSelector.java
@@ -4,26 +4,32 @@ import java.util.Collections;
 import java.util.Set;
 
 /**
- * TBD
+ * None selector implementation. Used in the ListView Renderer implementation because ListView
+ * has its own selection behavior.
  *
  * @author Arturo Gutiérrez Díaz-Guerra.
  */
-public class NoneSelector<T> implements Selector<T> {
+class NoneSelector<T> implements Selector<T> {
 
   @Override public void setSelectable(boolean isSelectable) {
     // Nothing
   }
 
-  @Override public void setSelected(boolean isSelected, T item) {
+  @Override public void setSelected(boolean isSelected, String itemId) {
     // Nothing
   }
 
-  @Override public boolean isSelected(T item) {
+  @Override
+  public void onBindRenderer(Renderer<T> renderer) {
+    // Nothing
+  }
+
+  @Override public boolean isSelected(String itemId) {
     return false;
   }
 
   @Override
-  public Set<T> getSelectedItems() {
+  public Set<String> getSelectedItemIds() {
     return Collections.emptySet();
   }
 }

--- a/renderers/src/main/java/com/pedrogomez/renderers/NoneSelector.java
+++ b/renderers/src/main/java/com/pedrogomez/renderers/NoneSelector.java
@@ -11,6 +11,10 @@ import java.util.Set;
  */
 class NoneSelector<T> implements Selector<T> {
 
+  @Override public boolean isSelectable() {
+    return false;
+  }
+
   @Override public void setSelectable(boolean isSelectable) {
     // Nothing
   }

--- a/renderers/src/main/java/com/pedrogomez/renderers/NoneSelector.java
+++ b/renderers/src/main/java/com/pedrogomez/renderers/NoneSelector.java
@@ -1,5 +1,8 @@
 package com.pedrogomez.renderers;
 
+import java.util.Collections;
+import java.util.Set;
+
 /**
  * TBD
  *
@@ -17,5 +20,10 @@ public class NoneSelector<T> implements Selector<T> {
 
   @Override public boolean isSelected(T item) {
     return false;
+  }
+
+  @Override
+  public Set<T> getSelectedItems() {
+    return Collections.emptySet();
   }
 }

--- a/renderers/src/main/java/com/pedrogomez/renderers/NoneSelector.java
+++ b/renderers/src/main/java/com/pedrogomez/renderers/NoneSelector.java
@@ -1,0 +1,21 @@
+package com.pedrogomez.renderers;
+
+/**
+ * TBD
+ *
+ * @author Arturo Gutiérrez Díaz-Guerra.
+ */
+public class NoneSelector<T> implements Selector<T> {
+
+  @Override public void setSelectable(boolean isSelectable) {
+    // Nothing
+  }
+
+  @Override public void setSelected(boolean isSelected, T item) {
+    // Nothing
+  }
+
+  @Override public boolean isSelected(T content) {
+    return false;
+  }
+}

--- a/renderers/src/main/java/com/pedrogomez/renderers/NoneSelector.java
+++ b/renderers/src/main/java/com/pedrogomez/renderers/NoneSelector.java
@@ -15,7 +15,7 @@ public class NoneSelector<T> implements Selector<T> {
     // Nothing
   }
 
-  @Override public boolean isSelected(T content) {
+  @Override public boolean isSelected(T item) {
     return false;
   }
 }

--- a/renderers/src/main/java/com/pedrogomez/renderers/RVRendererAdapter.java
+++ b/renderers/src/main/java/com/pedrogomez/renderers/RVRendererAdapter.java
@@ -20,12 +20,15 @@ import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.ViewGroup;
 import com.pedrogomez.renderers.exception.NullRendererBuiltException;
+
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
 import static com.pedrogomez.renderers.RVRendererAdapter.SelectionMode.MULTI;
 import static com.pedrogomez.renderers.RVRendererAdapter.SelectionMode.NONE;
+import static com.pedrogomez.renderers.RVRendererAdapter.SelectionMode.SINGLE;
 
 /**
  * RecyclerView.Adapter extension created to work RendererBuilders and Renderer instances. Other
@@ -123,13 +126,14 @@ public class RVRendererAdapter<T> extends RecyclerView.Adapter<RendererViewHolde
    * @param viewHolder with a Renderer class inside.
    * @param position to render.
    */
-  @Override public void onBindViewHolder(RendererViewHolder viewHolder, int position) {
+  @Override public void onBindViewHolder(final RendererViewHolder viewHolder, int position) {
     T content = getItem(position);
     Renderer<T> renderer = viewHolder.getRenderer();
     if (renderer == null) {
       throw new NullRendererBuiltException("RendererBuilder have to return a not null renderer");
     }
     renderer.setContent(content);
+    selector.onBindRenderer(renderer);
     updateRendererExtraValues(content, renderer, position);
     renderer.render();
   }
@@ -224,18 +228,24 @@ public class RVRendererAdapter<T> extends RecyclerView.Adapter<RendererViewHolde
     }
   }
 
+  /**
+   * Change the selector state to start or stop to listen the selections events from
+   * {@link Renderer#setSelected(boolean)} setSelected} method on Renderer
+   * @param isSelectable If the adapter should listen to selection events or not
+   */
   public void setSelectable(boolean isSelectable) {
     selector.setSelectable(isSelectable);
-    notifyDataSetChanged();
   }
 
-  public Set<T> getSelectedItems() {
-    return selector.getSelectedItems();
+  public Set<String> getSelectedItemIds() {
+    return selector.getSelectedItemIds();
   }
 
   private Selector<T> createSelectorFromMode(SelectionMode mode) {
     if (mode == MULTI) {
       return new MultiSelector<>();
+    } else if (mode == SINGLE) {
+      return new SingleSelector<>();
     }
     return new NoneSelector<>();
   }

--- a/renderers/src/main/java/com/pedrogomez/renderers/RVRendererAdapter.java
+++ b/renderers/src/main/java/com/pedrogomez/renderers/RVRendererAdapter.java
@@ -20,8 +20,6 @@ import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.ViewGroup;
 import com.pedrogomez.renderers.exception.NullRendererBuiltException;
-
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -231,6 +229,7 @@ public class RVRendererAdapter<T> extends RecyclerView.Adapter<RendererViewHolde
   /**
    * Change the selector state to start or stop to listen the selections events from
    * {@link Renderer#setSelected(boolean)} setSelected} method on Renderer
+   *
    * @param isSelectable If the adapter should listen to selection events or not
    */
   public void setSelectable(boolean isSelectable) {

--- a/renderers/src/main/java/com/pedrogomez/renderers/RVRendererAdapter.java
+++ b/renderers/src/main/java/com/pedrogomez/renderers/RVRendererAdapter.java
@@ -22,7 +22,6 @@ import android.view.ViewGroup;
 import com.pedrogomez.renderers.exception.NullRendererBuiltException;
 import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 
 import static com.pedrogomez.renderers.RVRendererAdapter.SelectionMode.MULTI;
 import static com.pedrogomez.renderers.RVRendererAdapter.SelectionMode.NONE;
@@ -236,8 +235,8 @@ public class RVRendererAdapter<T> extends RecyclerView.Adapter<RendererViewHolde
     selector.setSelectable(isSelectable);
   }
 
-  public Set<String> getSelectedItemIds() {
-    return selector.getSelectedItemIds();
+  public Collection<T> getSelectedItems() {
+    return selector.getSelectedItems().values();
   }
 
   private Selector<T> createSelectorFromMode(SelectionMode mode) {

--- a/renderers/src/main/java/com/pedrogomez/renderers/RVRendererAdapter.java
+++ b/renderers/src/main/java/com/pedrogomez/renderers/RVRendererAdapter.java
@@ -22,6 +22,7 @@ import android.view.ViewGroup;
 import com.pedrogomez.renderers.exception.NullRendererBuiltException;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 import static com.pedrogomez.renderers.RVRendererAdapter.SelectionMode.MULTI;
 import static com.pedrogomez.renderers.RVRendererAdapter.SelectionMode.NONE;
@@ -221,6 +222,15 @@ public class RVRendererAdapter<T> extends RecyclerView.Adapter<RendererViewHolde
       addAll(newList);
       diffResult.dispatchUpdatesTo(this);
     }
+  }
+
+  public void setSelectable(boolean isSelectable) {
+    selector.setSelectable(isSelectable);
+    notifyDataSetChanged();
+  }
+
+  public Set<T> getSelectedItems() {
+    return selector.getSelectedItems();
   }
 
   private Selector<T> createSelectorFromMode(SelectionMode mode) {

--- a/renderers/src/main/java/com/pedrogomez/renderers/Renderer.java
+++ b/renderers/src/main/java/com/pedrogomez/renderers/Renderer.java
@@ -174,6 +174,10 @@ public abstract class Renderer<T> implements Cloneable {
     return selector.isSelected(getItemId());
   }
 
+  protected boolean isSelectable() {
+    return selector.isSelectable();
+  }
+
   /**
    * Create a clone of the Renderer. This method is the base of the prototype mechanism implemented
    * to avoid create new objects from RendererBuilder. Pay an special attention implementing clone

--- a/renderers/src/main/java/com/pedrogomez/renderers/Renderer.java
+++ b/renderers/src/main/java/com/pedrogomez/renderers/Renderer.java
@@ -51,12 +51,10 @@ public abstract class Renderer<T> implements Cloneable {
    * be null in this method.
    * @param layoutInflater used to inflate the view.
    * @param parent used to inflate the view.
+   * @param selector used to manage selection when using with RecyclerView.
    */
-  public void onCreate(T content, LayoutInflater layoutInflater, ViewGroup parent) {
-    onCreate(content, layoutInflater, parent);
-  }
-
-  void onCreate(T content, LayoutInflater layoutInflater, ViewGroup parent, Selector<T> selector) {
+  public void onCreate(T content, LayoutInflater layoutInflater, ViewGroup parent,
+      Selector<T> selector) {
     this.content = content;
     this.selector = selector;
     this.rootView = inflate(layoutInflater, parent);

--- a/renderers/src/main/java/com/pedrogomez/renderers/Renderer.java
+++ b/renderers/src/main/java/com/pedrogomez/renderers/Renderer.java
@@ -111,14 +111,6 @@ public abstract class Renderer<T> implements Cloneable {
     this.content = content;
   }
 
-  protected void setSelected(boolean isSelected) {
-    selector.setSelected(isSelected, getContent());
-  }
-
-  protected boolean isSelected() {
-    return selector.isSelected(getContent());
-  }
-
   /**
    * Map all the widgets from the rootView to Renderer members.
    *
@@ -147,6 +139,18 @@ public abstract class Renderer<T> implements Cloneable {
    * Method where the presentation logic algorithm have to be declared or implemented.
    */
   public abstract void render();
+
+  public void setSelected(boolean isSelected) {
+    selector.setSelected(isSelected, getContent());
+  }
+
+  public void toggleSelection() {
+    setSelected(!isSelected());
+  }
+
+  public boolean isSelected() {
+    return selector.isSelected(getContent());
+  }
 
   /**
    * Create a clone of the Renderer. This method is the base of the prototype mechanism implemented

--- a/renderers/src/main/java/com/pedrogomez/renderers/Renderer.java
+++ b/renderers/src/main/java/com/pedrogomez/renderers/Renderer.java
@@ -174,7 +174,7 @@ public abstract class Renderer<T> implements Cloneable {
     return selector.isSelected(getItemId());
   }
 
-  protected boolean isSelectable() {
+  public boolean isSelectable() {
     return selector.isSelectable();
   }
 

--- a/renderers/src/main/java/com/pedrogomez/renderers/Renderer.java
+++ b/renderers/src/main/java/com/pedrogomez/renderers/Renderer.java
@@ -52,8 +52,11 @@ public abstract class Renderer<T> implements Cloneable {
    * @param layoutInflater used to inflate the view.
    * @param parent used to inflate the view.
    */
-  public void onCreate(T content, LayoutInflater layoutInflater, ViewGroup parent,
-      Selector<T> selector) {
+  public void onCreate(T content, LayoutInflater layoutInflater, ViewGroup parent) {
+    onCreate(content, layoutInflater, parent);
+  }
+
+  void onCreate(T content, LayoutInflater layoutInflater, ViewGroup parent, Selector<T> selector) {
     this.content = content;
     this.selector = selector;
     this.rootView = inflate(layoutInflater, parent);
@@ -160,14 +163,14 @@ public abstract class Renderer<T> implements Cloneable {
   /**
    * Toggle the current selection of the associated {@link #getContent() content}
    */
-  protected void toggleSelection() {
+  public void toggleSelection() {
     setSelected(!isSelected());
   }
 
   /**
    * @return the selection state of the associated {@link #getContent() content}
    */
-  protected boolean isSelected() {
+  public boolean isSelected() {
     return selector.isSelected(getItemId());
   }
 

--- a/renderers/src/main/java/com/pedrogomez/renderers/Renderer.java
+++ b/renderers/src/main/java/com/pedrogomez/renderers/Renderer.java
@@ -40,6 +40,7 @@ public abstract class Renderer<T> implements Cloneable {
 
   private View rootView;
   private T content;
+  private Selector<T> selector;
 
   /**
    * Method called when the renderer is going to be created. This method has the responsibility of
@@ -51,8 +52,10 @@ public abstract class Renderer<T> implements Cloneable {
    * @param layoutInflater used to inflate the view.
    * @param parent used to inflate the view.
    */
-  public void onCreate(T content, LayoutInflater layoutInflater, ViewGroup parent) {
+  public void onCreate(T content, LayoutInflater layoutInflater, ViewGroup parent,
+      Selector<T> selector) {
     this.content = content;
+    this.selector = selector;
     this.rootView = inflate(layoutInflater, parent);
     if (rootView == null) {
       throw new NotInflateViewException(
@@ -106,6 +109,14 @@ public abstract class Renderer<T> implements Cloneable {
    */
   protected void setContent(T content) {
     this.content = content;
+  }
+
+  protected void setSelected(boolean isSelected) {
+    selector.setSelected(isSelected, getContent());
+  }
+
+  protected boolean isSelected() {
+    return selector.isSelected(getContent());
   }
 
   /**

--- a/renderers/src/main/java/com/pedrogomez/renderers/Renderer.java
+++ b/renderers/src/main/java/com/pedrogomez/renderers/Renderer.java
@@ -155,7 +155,7 @@ public abstract class Renderer<T> implements Cloneable {
    * @param isSelected The selection state
    */
   public void setSelected(boolean isSelected) {
-    selector.setSelected(isSelected, getItemId());
+    selector.setSelected(isSelected, getItemId(), getContent());
   }
 
   /**

--- a/renderers/src/main/java/com/pedrogomez/renderers/Renderer.java
+++ b/renderers/src/main/java/com/pedrogomez/renderers/Renderer.java
@@ -103,9 +103,18 @@ public abstract class Renderer<T> implements Cloneable {
   }
 
   /**
+   * Only needed for {@link RVRendererAdapter RecyclerView} implementation. The id should be
+   * unique in order to provide a correct uniqueness selection between items
+   * @return the unique id from the associated content of this renderer
+   */
+  protected String getItemId() {
+    return String.valueOf(content.hashCode());
+  }
+
+  /**
    * Configures the content stored in the Renderer.
+   *  @param content associated to the Renderer instance.
    *
-   * @param content associated to the Renderer instance.
    */
   protected void setContent(T content) {
     this.content = content;
@@ -140,16 +149,26 @@ public abstract class Renderer<T> implements Cloneable {
    */
   public abstract void render();
 
+  /**
+   * Change the selection state of the associated content of this renderer
+   * @param isSelected The selection state
+   */
   public void setSelected(boolean isSelected) {
-    selector.setSelected(isSelected, getContent());
+    selector.setSelected(isSelected, getItemId());
   }
 
-  public void toggleSelection() {
+  /**
+   * Toggle the current selection of the associated {@link #getContent() content}
+   */
+  protected void toggleSelection() {
     setSelected(!isSelected());
   }
 
-  public boolean isSelected() {
-    return selector.isSelected(getContent());
+  /**
+   * @return the selection state of the associated {@link #getContent() content}
+   */
+  protected boolean isSelected() {
+    return selector.isSelected(getItemId());
   }
 
   /**

--- a/renderers/src/main/java/com/pedrogomez/renderers/RendererBuilder.java
+++ b/renderers/src/main/java/com/pedrogomez/renderers/RendererBuilder.java
@@ -24,7 +24,6 @@ import com.pedrogomez.renderers.exception.NullLayoutInflaterException;
 import com.pedrogomez.renderers.exception.NullParentException;
 import com.pedrogomez.renderers.exception.NullPrototypeClassException;
 import com.pedrogomez.renderers.exception.PrototypeNotFoundException;
-
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -157,7 +156,8 @@ public class RendererBuilder<T> {
     return this;
   }
 
-  public <G extends T> RendererBuilder<T> bind(Class<G> clazz, Class<? extends Renderer<? extends G>> prototypeClass) {
+  public <G extends T> RendererBuilder<T> bind(Class<G> clazz,
+      Class<? extends Renderer<? extends G>> prototypeClass) {
     if (clazz == null || prototypeClass == null) {
       throw new IllegalArgumentException(
           "The binding RecyclerView binding can't be configured using null instances");
@@ -231,7 +231,7 @@ public class RendererBuilder<T> {
     if (isRecyclable(convertView, content)) {
       renderer = recycle(convertView, content);
     } else {
-      renderer = createRenderer(content, parent);
+      renderer = createRenderer(content, parent, null);
     }
     return renderer;
   }
@@ -247,11 +247,11 @@ public class RendererBuilder<T> {
    *
    * @return ready to use RendererViewHolder instance.
    */
-  protected RendererViewHolder buildRendererViewHolder() {
+  protected RendererViewHolder buildRendererViewHolder(Selector<T> selector) {
     validateAttributesToCreateANewRendererViewHolder();
 
     Renderer renderer = getPrototypeByIndex(viewType).copy();
-    renderer.onCreate(null, layoutInflater, parent);
+    renderer.onCreate(null, layoutInflater, parent, selector);
     return new RendererViewHolder(renderer);
   }
 
@@ -276,10 +276,10 @@ public class RendererBuilder<T> {
    * @param parent used to inflate the view.
    * @return a new renderer.
    */
-  private Renderer createRenderer(T content, ViewGroup parent) {
+  private Renderer createRenderer(T content, ViewGroup parent, Selector<T> selector) {
     int prototypeIndex = getPrototypeIndex(content);
     Renderer renderer = getPrototypeByIndex(prototypeIndex).copy();
-    renderer.onCreate(content, layoutInflater, parent);
+    renderer.onCreate(content, layoutInflater, parent, selector);
     return renderer;
   }
 

--- a/renderers/src/main/java/com/pedrogomez/renderers/RendererBuilder.java
+++ b/renderers/src/main/java/com/pedrogomez/renderers/RendererBuilder.java
@@ -54,6 +54,7 @@ public class RendererBuilder<T> {
   private LayoutInflater layoutInflater;
   private Integer viewType;
   private Map<Class<? extends T>, Class<? extends Renderer>> binding;
+  private final NoneSelector<T> noneSelector = new NoneSelector<>();
 
   /**
    * Initializes a RendererBuilder with an empty prototypes collection. Using this constructor some
@@ -231,7 +232,7 @@ public class RendererBuilder<T> {
     if (isRecyclable(convertView, content)) {
       renderer = recycle(convertView, content);
     } else {
-      renderer = createRenderer(content, parent, null);
+      renderer = createRenderer(content, parent, noneSelector);
     }
     return renderer;
   }

--- a/renderers/src/main/java/com/pedrogomez/renderers/RendererViewHolder.java
+++ b/renderers/src/main/java/com/pedrogomez/renderers/RendererViewHolder.java
@@ -21,11 +21,11 @@ import android.support.v7.widget.RecyclerView;
  * RecyclerView.ViewHolder extension created to be able to use Renderer classes in RecyclerView
  * widgets. This class will be completely hidden to the library clients.
  */
-public class RendererViewHolder extends RecyclerView.ViewHolder {
+class RendererViewHolder extends RecyclerView.ViewHolder {
 
   private final Renderer renderer;
 
-  public RendererViewHolder(Renderer renderer) {
+  RendererViewHolder(Renderer renderer) {
     super(renderer.getRootView());
     this.renderer = renderer;
   }

--- a/renderers/src/main/java/com/pedrogomez/renderers/RendererViewHolder.java
+++ b/renderers/src/main/java/com/pedrogomez/renderers/RendererViewHolder.java
@@ -21,11 +21,11 @@ import android.support.v7.widget.RecyclerView;
  * RecyclerView.ViewHolder extension created to be able to use Renderer classes in RecyclerView
  * widgets. This class will be completely hidden to the library clients.
  */
-class RendererViewHolder extends RecyclerView.ViewHolder {
+public class RendererViewHolder extends RecyclerView.ViewHolder {
 
   private final Renderer renderer;
 
-  RendererViewHolder(Renderer renderer) {
+  public RendererViewHolder(Renderer renderer) {
     super(renderer.getRootView());
     this.renderer = renderer;
   }

--- a/renderers/src/main/java/com/pedrogomez/renderers/Selector.java
+++ b/renderers/src/main/java/com/pedrogomez/renderers/Selector.java
@@ -9,6 +9,8 @@ import java.util.Set;
  */
 interface Selector<T> {
 
+  boolean isSelectable();
+
   void setSelectable(boolean isSelectable);
 
   boolean isSelected(String itemId);

--- a/renderers/src/main/java/com/pedrogomez/renderers/Selector.java
+++ b/renderers/src/main/java/com/pedrogomez/renderers/Selector.java
@@ -3,17 +3,19 @@ package com.pedrogomez.renderers;
 import java.util.Set;
 
 /**
- * TBD
+ * Interface created to represent a items selector over Renderers.
  *
  * @author Arturo Gutiérrez Díaz-Guerra.
  */
-public interface Selector<T> {
+interface Selector<T> {
 
   void setSelectable(boolean isSelectable);
 
-  void setSelected(boolean isSelected, T item);
+  boolean isSelected(String itemId);
 
-  boolean isSelected(T item);
+  void setSelected(boolean isSelected, String itemId);
 
-  Set<T> getSelectedItems();
+  void onBindRenderer(Renderer<T> renderer);
+
+  Set<String> getSelectedItemIds();
 }

--- a/renderers/src/main/java/com/pedrogomez/renderers/Selector.java
+++ b/renderers/src/main/java/com/pedrogomez/renderers/Selector.java
@@ -11,5 +11,5 @@ public interface Selector<T> {
 
   void setSelected(boolean isSelected, T item);
 
-  boolean isSelected(T content);
+  boolean isSelected(T item);
 }

--- a/renderers/src/main/java/com/pedrogomez/renderers/Selector.java
+++ b/renderers/src/main/java/com/pedrogomez/renderers/Selector.java
@@ -1,0 +1,15 @@
+package com.pedrogomez.renderers;
+
+/**
+ * TBD
+ *
+ * @author Arturo Gutiérrez Díaz-Guerra.
+ */
+public interface Selector<T> {
+
+  void setSelectable(boolean isSelectable);
+
+  void setSelected(boolean isSelected, T item);
+
+  boolean isSelected(T content);
+}

--- a/renderers/src/main/java/com/pedrogomez/renderers/Selector.java
+++ b/renderers/src/main/java/com/pedrogomez/renderers/Selector.java
@@ -7,7 +7,7 @@ import java.util.Set;
  *
  * @author Arturo Gutiérrez Díaz-Guerra.
  */
-interface Selector<T> {
+public interface Selector<T> {
 
   boolean isSelectable();
 

--- a/renderers/src/main/java/com/pedrogomez/renderers/Selector.java
+++ b/renderers/src/main/java/com/pedrogomez/renderers/Selector.java
@@ -1,6 +1,6 @@
 package com.pedrogomez.renderers;
 
-import java.util.Set;
+import java.util.Map;
 
 /**
  * Interface created to represent a items selector over Renderers.
@@ -15,9 +15,9 @@ public interface Selector<T> {
 
   boolean isSelected(String itemId);
 
-  void setSelected(boolean isSelected, String itemId);
+  void setSelected(boolean isSelected, String itemId, T item);
 
   void onBindRenderer(Renderer<T> renderer);
 
-  Set<String> getSelectedItemIds();
+  Map<String, T> getSelectedItems();
 }

--- a/renderers/src/main/java/com/pedrogomez/renderers/Selector.java
+++ b/renderers/src/main/java/com/pedrogomez/renderers/Selector.java
@@ -1,5 +1,7 @@
 package com.pedrogomez.renderers;
 
+import java.util.Set;
+
 /**
  * TBD
  *
@@ -12,4 +14,6 @@ public interface Selector<T> {
   void setSelected(boolean isSelected, T item);
 
   boolean isSelected(T item);
+
+  Set<T> getSelectedItems();
 }

--- a/renderers/src/main/java/com/pedrogomez/renderers/SingleSelector.java
+++ b/renderers/src/main/java/com/pedrogomez/renderers/SingleSelector.java
@@ -1,5 +1,7 @@
 package com.pedrogomez.renderers;
 
+import java.util.Map;
+
 /**
  * Implementation of selector for single selection. Basically, it's the multi selector
  * implementation but deselecting the previous selected items before selecting the new one.
@@ -8,16 +10,15 @@ package com.pedrogomez.renderers;
  */
 class SingleSelector<T> extends MultiSelector<T> {
 
-    @Override
-    public void setSelected(boolean isSelected, String itemId) {
-        if (isSelected) {
-            for (String selectedItemId : getSelectedItemIds()) {
-                if (!itemId.equals(selectedItemId)) {
-                    super.setSelected(false, selectedItemId);
-                }
-            }
+  @Override public void setSelected(boolean isSelected, String itemId, T item) {
+    if (isSelected) {
+      for (Map.Entry<String, T> entry : getSelectedItems().entrySet()) {
+        if (!itemId.equals(entry.getKey())) {
+          super.setSelected(false, entry.getKey(), item);
         }
-
-        super.setSelected(isSelected, itemId);
+      }
     }
+
+    super.setSelected(isSelected, itemId, item);
+  }
 }

--- a/renderers/src/main/java/com/pedrogomez/renderers/SingleSelector.java
+++ b/renderers/src/main/java/com/pedrogomez/renderers/SingleSelector.java
@@ -1,22 +1,23 @@
 package com.pedrogomez.renderers;
 
 /**
- * TBD
+ * Implementation of selector for single selection. Basically, it's the multi selector
+ * implementation but deselecting the previous selected items before selecting the new one.
  *
  * @author Arturo Gutiérrez Díaz-Guerra.
  */
-public class SingleSelector<T> extends MultiSelector<T> {
+class SingleSelector<T> extends MultiSelector<T> {
 
     @Override
-    public void setSelected(boolean isSelected, T item) {
+    public void setSelected(boolean isSelected, String itemId) {
         if (isSelected) {
-            for (T selectedItem : getSelectedItems()) {
-                if (!selectedItem.equals(item)) {
-                    super.setSelected(false, selectedItem);
+            for (String selectedItemId : getSelectedItemIds()) {
+                if (!itemId.equals(selectedItemId)) {
+                    super.setSelected(false, selectedItemId);
                 }
             }
         }
 
-        super.setSelected(isSelected, item);
+        super.setSelected(isSelected, itemId);
     }
 }

--- a/renderers/src/main/java/com/pedrogomez/renderers/SingleSelector.java
+++ b/renderers/src/main/java/com/pedrogomez/renderers/SingleSelector.java
@@ -1,0 +1,22 @@
+package com.pedrogomez.renderers;
+
+/**
+ * TBD
+ *
+ * @author Arturo Gutiérrez Díaz-Guerra.
+ */
+public class SingleSelector<T> extends MultiSelector<T> {
+
+    @Override
+    public void setSelected(boolean isSelected, T item) {
+        if (isSelected) {
+            for (T selectedItem : getSelectedItems()) {
+                if (!selectedItem.equals(item)) {
+                    super.setSelected(false, selectedItem);
+                }
+            }
+        }
+
+        super.setSelected(isSelected, item);
+    }
+}

--- a/renderers/src/test/java/com/pedrogomez/renderers/MultiSelectorTest.java
+++ b/renderers/src/test/java/com/pedrogomez/renderers/MultiSelectorTest.java
@@ -1,5 +1,6 @@
 package com.pedrogomez.renderers;
 
+import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -7,8 +8,6 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
-
-import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -19,14 +18,14 @@ import static org.mockito.Mockito.when;
 
 @Config(emulateSdk = 16) @RunWith(RobolectricTestRunner.class) public class MultiSelectorTest {
 
-  private static final java.lang.String ANY_ITEM_ID = "1";
+  private static final String ANY_ITEM_ID = "1";
+  private static final Object ANY_ITEM = new Object();
 
   private MultiSelector<Object> selector;
 
   @Mock private ObjectRenderer mockedRenderer;
 
-  @Before
-  public void setUp() {
+  @Before public void setUp() {
     initializeSelector();
     initializeMocks();
   }
@@ -36,9 +35,9 @@ import static org.mockito.Mockito.when;
     givenANotSelectableSelector();
     givenASelectedItem();
 
-    Set<String> selectedItemIds = selector.getSelectedItemIds();
+    Map<String, Object> selectedItems = selector.getSelectedItems();
 
-    assertEquals(0, selectedItemIds.size());
+    assertEquals(0, selectedItems.size());
     assertFalse(selector.isSelected(ANY_ITEM_ID));
   }
 
@@ -47,9 +46,9 @@ import static org.mockito.Mockito.when;
     givenASelectableSelector();
     givenASelectedItem();
 
-    Set<String> selectedItemIds = selector.getSelectedItemIds();
+    Map<String, Object> selectedItems = selector.getSelectedItems();
 
-    assertTrue(selectedItemIds.contains(ANY_ITEM_ID));
+    assertTrue(selectedItems.containsKey(ANY_ITEM_ID));
     assertTrue(selector.isSelected(ANY_ITEM_ID));
   }
 
@@ -57,7 +56,7 @@ import static org.mockito.Mockito.when;
     givenABindedRendererWithItemId();
     givenASelectableSelector();
 
-    selector.setSelected(true, ANY_ITEM_ID);
+    selector.setSelected(true, ANY_ITEM_ID, ANY_ITEM);
 
     verify(mockedRenderer).render();
   }
@@ -73,7 +72,7 @@ import static org.mockito.Mockito.when;
   }
 
   private void givenASelectedItem() {
-    selector.setSelected(true, ANY_ITEM_ID);
+    selector.setSelected(true, ANY_ITEM_ID, ANY_ITEM);
   }
 
   private void givenANotSelectableSelector() {

--- a/renderers/src/test/java/com/pedrogomez/renderers/MultiSelectorTest.java
+++ b/renderers/src/test/java/com/pedrogomez/renderers/MultiSelectorTest.java
@@ -1,0 +1,99 @@
+package com.pedrogomez.renderers;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@Config(emulateSdk = 16) @RunWith(RobolectricTestRunner.class) public class MultiSelectorTest {
+
+  private static final java.lang.String ANY_ITEM_ID = "1";
+
+  private MultiSelector<Object> selector;
+
+  @Mock private ObjectRenderer mockedRenderer;
+
+  @Before
+  public void setUp() {
+    initializeSelector();
+    initializeMocks();
+  }
+
+  @Test public void shouldNotSelectAnyItemIfItIsNotInSelectableState() {
+    givenABindedRendererWithItemId();
+    givenANotSelectableSelector();
+    givenASelectedItem();
+
+    Set<String> selectedItemIds = selector.getSelectedItemIds();
+
+    assertEquals(0, selectedItemIds.size());
+    assertFalse(selector.isSelected(ANY_ITEM_ID));
+  }
+
+  @Test public void shouldSelectTheItemIfItIsInSelectableState() {
+    givenABindedRendererWithItemId();
+    givenASelectableSelector();
+    givenASelectedItem();
+
+    Set<String> selectedItemIds = selector.getSelectedItemIds();
+
+    assertTrue(selectedItemIds.contains(ANY_ITEM_ID));
+    assertTrue(selector.isSelected(ANY_ITEM_ID));
+  }
+
+  @Test public void shouldRefreshRendererWhenItsSelected() {
+    givenABindedRendererWithItemId();
+    givenASelectableSelector();
+
+    selector.setSelected(true, ANY_ITEM_ID);
+
+    verify(mockedRenderer).render();
+  }
+
+  @Test public void shouldRefreshAllRenderersWhenDisablingSelectableState() {
+    givenABindedRendererWithItemId();
+    givenASelectableSelector();
+    givenASelectedItem();
+
+    selector.setSelectable(false);
+
+    verify(mockedRenderer, times(2)).render();
+  }
+
+  private void givenASelectedItem() {
+    selector.setSelected(true, ANY_ITEM_ID);
+  }
+
+  private void givenANotSelectableSelector() {
+    selector.setSelectable(false);
+  }
+
+  private void givenASelectableSelector() {
+    selector.setSelectable(true);
+  }
+
+  private void givenABindedRendererWithItemId() {
+    when(mockedRenderer.getItemId()).thenReturn(ANY_ITEM_ID);
+    selector.onBindRenderer(mockedRenderer);
+  }
+
+  private void initializeSelector() {
+    selector = new MultiSelector<>();
+  }
+
+  private void initializeMocks() {
+    MockitoAnnotations.initMocks(this);
+  }
+}

--- a/renderers/src/test/java/com/pedrogomez/renderers/RVRendererAdapterTest.java
+++ b/renderers/src/test/java/com/pedrogomez/renderers/RVRendererAdapterTest.java
@@ -32,6 +32,8 @@ import java.util.Collection;
 import java.util.LinkedList;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.notNull;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -92,14 +94,14 @@ import static org.mockito.Mockito.when;
 
   @Test public void shouldBuildRendererUsingAllNeededDependencies() {
     when(mockedCollection.get(ANY_POSITION)).thenReturn(ANY_OBJECT);
-    when(mockedRendererBuilder.buildRendererViewHolder()).thenReturn(mockedRendererViewHolder);
+    when(mockedRendererBuilder.buildRendererViewHolder((Selector) any())).thenReturn(mockedRendererViewHolder);
 
     adapter.onCreateViewHolder(mockedParent, ANY_ITEM_VIEW_TYPE);
 
     verify(mockedRendererBuilder).withParent(mockedParent);
     verify(mockedRendererBuilder).withLayoutInflater((LayoutInflater) notNull());
     verify(mockedRendererBuilder).withViewType(ANY_ITEM_VIEW_TYPE);
-    verify(mockedRendererBuilder).buildRendererViewHolder();
+    verify(mockedRendererBuilder).buildRendererViewHolder((Selector) any());
   }
 
   @Test public void shouldGetRendererFromViewHolderAndCallUpdateRendererExtraValuesOnBind() {

--- a/renderers/src/test/java/com/pedrogomez/renderers/RVRendererAdapterTest.java
+++ b/renderers/src/test/java/com/pedrogomez/renderers/RVRendererAdapterTest.java
@@ -19,6 +19,8 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import com.pedrogomez.renderers.exception.NullRendererBuiltException;
+import java.util.Collection;
+import java.util.LinkedList;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -28,12 +30,8 @@ import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
-import java.util.Collection;
-import java.util.LinkedList;
-
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.notNull;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;

--- a/renderers/src/test/java/com/pedrogomez/renderers/RendererTest.java
+++ b/renderers/src/test/java/com/pedrogomez/renderers/RendererTest.java
@@ -28,6 +28,7 @@ public class RendererTest {
   @Mock private LayoutInflater mockedLayoutInflater;
   @Mock private ViewGroup mockedParent;
   @Mock private View mockedView;
+  @Mock private Selector<Object> mockedSelector;
 
   @Before public void setUp() {
     initializeRenderer();
@@ -98,7 +99,7 @@ public class RendererTest {
   }
 
   private void onCreateRenderer() {
-    renderer.onCreate(mockedContent, mockedLayoutInflater, mockedParent);
+    renderer.onCreate(mockedContent, mockedLayoutInflater, mockedParent, mockedSelector);
   }
 
   private void onRecycleRenderer() {

--- a/renderers/src/test/java/com/pedrogomez/renderers/SingleSelectorTest.java
+++ b/renderers/src/test/java/com/pedrogomez/renderers/SingleSelectorTest.java
@@ -1,0 +1,70 @@
+package com.pedrogomez.renderers;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@Config(emulateSdk = 16) @RunWith(RobolectricTestRunner.class) public class SingleSelectorTest {
+
+  private static final String FIRST_ITEM_ID = "1";
+  private static final String SECOND_ITEM_ID = "2";
+
+  private SingleSelector<Object> selector;
+
+  @Mock private ObjectRenderer mockedFirstRenderer;
+  @Mock private ObjectRenderer mockedSecondRenderer;
+
+  @Before
+  public void setUp() {
+    initializeSelector();
+    initializeMocks();
+  }
+
+  @Test public void shouldDeselectAnyPreviousItemWhenAnotherItemIsSelected() {
+    givenBindedRenderersWithItemIds();
+    givenASelectableSelector();
+    givenFirstSelectedItem();
+
+    selector.setSelected(true, SECOND_ITEM_ID);
+    Set<String> selectedItemIds = selector.getSelectedItemIds();
+
+    assertFalse(selector.isSelected(FIRST_ITEM_ID));
+    assertTrue(selectedItemIds.contains(SECOND_ITEM_ID));
+    assertEquals(1, selectedItemIds.size());
+  }
+
+  private void givenFirstSelectedItem() {
+    selector.setSelected(true, FIRST_ITEM_ID);
+  }
+
+  private void givenASelectableSelector() {
+    selector.setSelectable(true);
+  }
+
+  private void givenBindedRenderersWithItemIds() {
+    when(mockedFirstRenderer.getItemId()).thenReturn(FIRST_ITEM_ID);
+    when(mockedSecondRenderer.getItemId()).thenReturn(SECOND_ITEM_ID);
+    selector.onBindRenderer(mockedFirstRenderer);
+    selector.onBindRenderer(mockedSecondRenderer);
+  }
+
+  private void initializeSelector() {
+    selector = new SingleSelector<>();
+  }
+
+  private void initializeMocks() {
+    MockitoAnnotations.initMocks(this);
+  }
+}

--- a/renderers/src/test/java/com/pedrogomez/renderers/SingleSelectorTest.java
+++ b/renderers/src/test/java/com/pedrogomez/renderers/SingleSelectorTest.java
@@ -1,6 +1,6 @@
 package com.pedrogomez.renderers;
 
-import java.util.Set;
+import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -18,6 +18,8 @@ import static org.mockito.Mockito.when;
 
   private static final String FIRST_ITEM_ID = "1";
   private static final String SECOND_ITEM_ID = "2";
+  private static final Object FIRST_ITEM = new Object();
+  private static final Object SECOND_ITEM = new Object();
 
   private SingleSelector<Object> selector;
 
@@ -34,16 +36,16 @@ import static org.mockito.Mockito.when;
     givenASelectableSelector();
     givenFirstSelectedItem();
 
-    selector.setSelected(true, SECOND_ITEM_ID);
-    Set<String> selectedItemIds = selector.getSelectedItemIds();
+    selector.setSelected(true, SECOND_ITEM_ID, SECOND_ITEM);
+    Map<String, Object> selectedItems = selector.getSelectedItems();
 
     assertFalse(selector.isSelected(FIRST_ITEM_ID));
-    assertTrue(selectedItemIds.contains(SECOND_ITEM_ID));
-    assertEquals(1, selectedItemIds.size());
+    assertTrue(selectedItems.containsKey(SECOND_ITEM_ID));
+    assertEquals(1, selectedItems.size());
   }
 
   private void givenFirstSelectedItem() {
-    selector.setSelected(true, FIRST_ITEM_ID);
+    selector.setSelected(true, FIRST_ITEM_ID, FIRST_ITEM);
   }
 
   private void givenASelectableSelector() {

--- a/renderers/src/test/java/com/pedrogomez/renderers/SingleSelectorTest.java
+++ b/renderers/src/test/java/com/pedrogomez/renderers/SingleSelectorTest.java
@@ -1,5 +1,6 @@
 package com.pedrogomez.renderers;
 
+import java.util.Set;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -8,12 +9,9 @@ import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
-import java.util.Set;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @Config(emulateSdk = 16) @RunWith(RobolectricTestRunner.class) public class SingleSelectorTest {
@@ -26,8 +24,7 @@ import static org.mockito.Mockito.when;
   @Mock private ObjectRenderer mockedFirstRenderer;
   @Mock private ObjectRenderer mockedSecondRenderer;
 
-  @Before
-  public void setUp() {
+  @Before public void setUp() {
     initializeSelector();
     initializeMocks();
   }

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -43,6 +43,10 @@
         android:name=".ui.RecyclerViewActivity"
         android:label="@string/app_name"/>
 
+    <activity
+        android:name=".ui.MultiSelectRecyclerViewActivity"
+        android:label="@string/app_name"/>
+
   </application>
 
 </manifest>

--- a/sample/src/main/java/com/pedrogomez/renderers/sample/model/RandomVideoCollectionGenerator.java
+++ b/sample/src/main/java/com/pedrogomez/renderers/sample/model/RandomVideoCollectionGenerator.java
@@ -68,20 +68,20 @@ public class RandomVideoCollectionGenerator {
    * Initialize VIDEO_INFO data.
    */
   private void initializeVideoInfo() {
-    VIDEO_INFO.put("The Big Bang Theory", "http://thetvdb.com/banners/_cache/posters/80379-9.jpg");
-    VIDEO_INFO.put("Breaking Bad", "http://thetvdb.com/banners/_cache/posters/81189-22.jpg");
-    VIDEO_INFO.put("Arrow", "http://thetvdb.com/banners/_cache/posters/257655-15.jpg");
-    VIDEO_INFO.put("Game of Thrones", "http://thetvdb.com/banners/_cache/posters/121361-26.jpg");
-    VIDEO_INFO.put("Lost", "http://thetvdb.com/banners/_cache/posters/73739-2.jpg");
+    VIDEO_INFO.put("The Big Bang Theory", "https://thetvdb.com/banners/_cache/posters/80379-9.jpg");
+    VIDEO_INFO.put("Breaking Bad", "https://thetvdb.com/banners/_cache/posters/81189-22.jpg");
+    VIDEO_INFO.put("Arrow", "https://thetvdb.com/banners/_cache/posters/257655-15.jpg");
+    VIDEO_INFO.put("Game of Thrones", "https://thetvdb.com/banners/_cache/posters/121361-26.jpg");
+    VIDEO_INFO.put("Lost", "https://thetvdb.com/banners/_cache/posters/73739-2.jpg");
     VIDEO_INFO.put("How I met your mother",
-        "http://thetvdb.com/banners/_cache/posters/75760-29.jpg");
-    VIDEO_INFO.put("Dexter", "http://thetvdb.com/banners/_cache/posters/79349-24.jpg");
-    VIDEO_INFO.put("Sleepy Hollow", "http://thetvdb.com/banners/_cache/posters/269578-5.jpg");
-    VIDEO_INFO.put("The Vampire Diaries", "http://thetvdb.com/banners/_cache/posters/95491-27.jpg");
-    VIDEO_INFO.put("Friends", "http://thetvdb.com/banners/_cache/posters/79168-4.jpg");
-    VIDEO_INFO.put("New Girl", "http://thetvdb.com/banners/_cache/posters/248682-9.jpg");
-    VIDEO_INFO.put("The Mentalist", "http://thetvdb.com/banners/_cache/posters/82459-1.jpg");
-    VIDEO_INFO.put("Sons of Anarchy", "http://thetvdb.com/banners/_cache/posters/82696-1.jpg");
+        "https://thetvdb.com/banners/_cache/posters/75760-29.jpg");
+    VIDEO_INFO.put("Dexter", "https://thetvdb.com/banners/_cache/posters/79349-24.jpg");
+    VIDEO_INFO.put("Sleepy Hollow", "https://thetvdb.com/banners/_cache/posters/269578-5.jpg");
+    VIDEO_INFO.put("The Vampire Diaries", "https://thetvdb.com/banners/_cache/posters/95491-27.jpg");
+    VIDEO_INFO.put("Friends", "https://thetvdb.com/banners/_cache/posters/79168-4.jpg");
+    VIDEO_INFO.put("New Girl", "https://thetvdb.com/banners/_cache/posters/248682-9.jpg");
+    VIDEO_INFO.put("The Mentalist", "https://thetvdb.com/banners/_cache/posters/82459-1.jpg");
+    VIDEO_INFO.put("Sons of Anarchy", "https://thetvdb.com/banners/_cache/posters/82696-1.jpg");
   }
 
   /**

--- a/sample/src/main/java/com/pedrogomez/renderers/sample/model/RandomVideoCollectionGenerator.java
+++ b/sample/src/main/java/com/pedrogomez/renderers/sample/model/RandomVideoCollectionGenerator.java
@@ -77,7 +77,8 @@ public class RandomVideoCollectionGenerator {
         "https://thetvdb.com/banners/_cache/posters/75760-29.jpg");
     VIDEO_INFO.put("Dexter", "https://thetvdb.com/banners/_cache/posters/79349-24.jpg");
     VIDEO_INFO.put("Sleepy Hollow", "https://thetvdb.com/banners/_cache/posters/269578-5.jpg");
-    VIDEO_INFO.put("The Vampire Diaries", "https://thetvdb.com/banners/_cache/posters/95491-27.jpg");
+    VIDEO_INFO.put("The Vampire Diaries",
+        "https://thetvdb.com/banners/_cache/posters/95491-27.jpg");
     VIDEO_INFO.put("Friends", "https://thetvdb.com/banners/_cache/posters/79168-4.jpg");
     VIDEO_INFO.put("New Girl", "https://thetvdb.com/banners/_cache/posters/248682-9.jpg");
     VIDEO_INFO.put("The Mentalist", "https://thetvdb.com/banners/_cache/posters/82459-1.jpg");

--- a/sample/src/main/java/com/pedrogomez/renderers/sample/model/RandomVideoCollectionGenerator.java
+++ b/sample/src/main/java/com/pedrogomez/renderers/sample/model/RandomVideoCollectionGenerator.java
@@ -47,7 +47,7 @@ public class RandomVideoCollectionGenerator {
    * @return VideoCollection generated.
    */
   public VideoCollection generate(final int videoCount) {
-    List<Video> videos = new LinkedList<Video>();
+    List<Video> videos = new LinkedList<>();
     for (int i = 0; i < videoCount; i++) {
       Video video = generateRandomVideo();
       videos.add(video);
@@ -61,7 +61,7 @@ public class RandomVideoCollectionGenerator {
       Video video = generateRandomVideo();
       videos.add(video);
     }
-    return new ListAdapteeCollection<Video>(videos);
+    return new ListAdapteeCollection<>(videos);
   }
 
   /**
@@ -95,6 +95,7 @@ public class RandomVideoCollectionGenerator {
     configureLikeStatus(video);
     configureLiveStatus(video);
     configureTitleAndThumbnail(video);
+    configureUniqueId(video);
     return video;
   }
 
@@ -120,6 +121,11 @@ public class RandomVideoCollectionGenerator {
     video.setTitle(title);
     String thumbnail = getValueForIndex(randomIndex);
     video.setThumbnail(thumbnail);
+  }
+
+  private void configureUniqueId(final Video video) {
+    int randomIndex = random.nextInt();
+    video.setId(String.valueOf(randomIndex));
   }
 
   private String getKeyForIndex(int randomIndex) {

--- a/sample/src/main/java/com/pedrogomez/renderers/sample/model/Video.java
+++ b/sample/src/main/java/com/pedrogomez/renderers/sample/model/Video.java
@@ -27,6 +27,7 @@ public class Video {
   private boolean live;
   private String thumbnail;
   private String title;
+  private String id;
 
   public boolean isFavorite() {
     return favorite;
@@ -66,6 +67,14 @@ public class Video {
 
   public void setLive(boolean live) {
     this.live = live;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
   }
 
   @Override public boolean equals(Object obj) {

--- a/sample/src/main/java/com/pedrogomez/renderers/sample/ui/MainActivity.java
+++ b/sample/src/main/java/com/pedrogomez/renderers/sample/ui/MainActivity.java
@@ -25,6 +25,10 @@ public class MainActivity extends BaseActivity {
     open(RecyclerViewActivity.class);
   }
 
+  @OnClick(R.id.bt_open_multiselect_rv_sample) public void openMultiSelectRecyclerViewSample() {
+    open(MultiSelectRecyclerViewActivity.class);
+  }
+
   private void open(Class activity) {
     Intent intent = new Intent(this, activity);
     startActivity(intent);

--- a/sample/src/main/java/com/pedrogomez/renderers/sample/ui/MainActivity.java
+++ b/sample/src/main/java/com/pedrogomez/renderers/sample/ui/MainActivity.java
@@ -26,11 +26,24 @@ public class MainActivity extends BaseActivity {
   }
 
   @OnClick(R.id.bt_open_multiselect_rv_sample) public void openMultiSelectRecyclerViewSample() {
+    Intent intent = getIntentForClass(MultiSelectRecyclerViewActivity.class);
+    intent.putExtra(MultiSelectRecyclerViewActivity.IS_MULTI_SELECT_EXTRA, true);
+    open(intent);
+  }
+
+  @OnClick(R.id.bt_open_singleselect_rv_sample) public void openSingleSelectRecyclerViewSample() {
     open(MultiSelectRecyclerViewActivity.class);
   }
 
   private void open(Class activity) {
-    Intent intent = new Intent(this, activity);
+    startActivity(getIntentForClass(activity));
+  }
+
+  private void open(Intent intent) {
     startActivity(intent);
+  }
+
+  private Intent getIntentForClass(Class activity) {
+    return new Intent(this, activity);
   }
 }

--- a/sample/src/main/java/com/pedrogomez/renderers/sample/ui/MultiSelectRecyclerViewActivity.java
+++ b/sample/src/main/java/com/pedrogomez/renderers/sample/ui/MultiSelectRecyclerViewActivity.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2014 Pedro Vicente Gómez Sánchez.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pedrogomez.renderers.sample.ui;
+
+import android.os.Bundle;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
+import butterknife.Bind;
+import com.pedrogomez.renderers.AdapteeCollection;
+import com.pedrogomez.renderers.RVRendererAdapter;
+import com.pedrogomez.renderers.RendererBuilder;
+import com.pedrogomez.renderers.sample.R;
+import com.pedrogomez.renderers.sample.model.RandomVideoCollectionGenerator;
+import com.pedrogomez.renderers.sample.model.Video;
+import com.pedrogomez.renderers.sample.ui.renderers.RemovableVideoRenderer;
+import java.util.ArrayList;
+import java.util.Collection;
+
+import static com.pedrogomez.renderers.RVRendererAdapter.SelectionMode.MULTI;
+
+/**
+ * RecyclerViewActivity for the Renderers demo.
+ *
+ * @author Pedro Vicente Gómez Sánchez.
+ */
+public class MultiSelectRecyclerViewActivity extends BaseActivity {
+
+  private static final int VIDEO_COUNT = 100;
+
+  @Bind(R.id.rv_renderers) RecyclerView recyclerView;
+
+  private RVRendererAdapter<Video> adapter;
+
+  @Override protected void onCreate(Bundle savedInstanceState) {
+    setContentView(R.layout.activity_recycler_view);
+    super.onCreate(savedInstanceState);
+    initAdapter();
+    initRecyclerView();
+  }
+
+  /**
+   * Initialize RVRendererAdapter
+   */
+  private void initAdapter() {
+    RandomVideoCollectionGenerator randomVideoCollectionGenerator =
+        new RandomVideoCollectionGenerator();
+    final AdapteeCollection<Video> videoCollection =
+        randomVideoCollectionGenerator.generateListAdapteeVideoCollection(VIDEO_COUNT);
+    RendererBuilder<Video> rendererBuilder = new RendererBuilder<Video>().withPrototype(
+        new RemovableVideoRenderer(new RemovableVideoRenderer.Listener() {
+          @Override public void onRemoveButtonTapped(Video video) {
+            ArrayList<Video> clonedList =
+                new ArrayList<>((Collection<? extends Video>) videoCollection);
+            clonedList.remove(video);
+            adapter.diffUpdate(clonedList);
+          }
+        })).bind(Video.class, RemovableVideoRenderer.class);
+
+    adapter = new RVRendererAdapter<>(rendererBuilder, videoCollection, MULTI);
+  }
+
+  /**
+   * Initialize ListVideo with our RVRendererAdapter.
+   */
+  private void initRecyclerView() {
+    recyclerView.setLayoutManager(new LinearLayoutManager(this));
+    recyclerView.setAdapter(adapter);
+  }
+}

--- a/sample/src/main/java/com/pedrogomez/renderers/sample/ui/MultiSelectRecyclerViewActivity.java
+++ b/sample/src/main/java/com/pedrogomez/renderers/sample/ui/MultiSelectRecyclerViewActivity.java
@@ -25,6 +25,7 @@ import android.view.MenuItem;
 import butterknife.Bind;
 import com.pedrogomez.renderers.AdapteeCollection;
 import com.pedrogomez.renderers.RVRendererAdapter;
+import com.pedrogomez.renderers.RVRendererAdapter.SelectionMode;
 import com.pedrogomez.renderers.RendererBuilder;
 import com.pedrogomez.renderers.sample.R;
 import com.pedrogomez.renderers.sample.model.RandomVideoCollectionGenerator;
@@ -35,6 +36,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 
 import static com.pedrogomez.renderers.RVRendererAdapter.SelectionMode.MULTI;
+import static com.pedrogomez.renderers.RVRendererAdapter.SelectionMode.SINGLE;
 
 /**
  * RecyclerViewActivity for the Renderers demo.
@@ -42,6 +44,8 @@ import static com.pedrogomez.renderers.RVRendererAdapter.SelectionMode.MULTI;
  * @author Pedro Vicente Gómez Sánchez.
  */
 public class MultiSelectRecyclerViewActivity extends BaseActivity {
+
+  public static final String IS_MULTI_SELECT_EXTRA = "multiselect";
 
   private static final int VIDEO_COUNT = 100;
 
@@ -75,14 +79,12 @@ public class MultiSelectRecyclerViewActivity extends BaseActivity {
   @Override protected void onCreate(Bundle savedInstanceState) {
     setContentView(R.layout.activity_recycler_view);
     super.onCreate(savedInstanceState);
-    initAdapter();
+    boolean isMultiSelect = getIntent().getBooleanExtra(IS_MULTI_SELECT_EXTRA, false);
+    initAdapter(isMultiSelect);
     initRecyclerView();
   }
 
-  /**
-   * Initialize RVRendererAdapter
-   */
-  private void initAdapter() {
+  private void initAdapter(boolean isMultiSelect) {
     RandomVideoCollectionGenerator randomVideoCollectionGenerator =
         new RandomVideoCollectionGenerator();
     final AdapteeCollection<Video> videoCollection =
@@ -107,7 +109,8 @@ public class MultiSelectRecyclerViewActivity extends BaseActivity {
               }
             })).bind(Video.class, SelectableVideoRenderer.class);
 
-    adapter = new RVRendererAdapter<>(rendererBuilder, videoCollection, MULTI);
+    SelectionMode selectionMode = isMultiSelect ? MULTI : SINGLE;
+    adapter = new RVRendererAdapter<>(rendererBuilder, videoCollection, selectionMode);
   }
 
   /**

--- a/sample/src/main/java/com/pedrogomez/renderers/sample/ui/renderers/SelectableVideoRenderer.java
+++ b/sample/src/main/java/com/pedrogomez/renderers/sample/ui/renderers/SelectableVideoRenderer.java
@@ -3,7 +3,6 @@ package com.pedrogomez.renderers.sample.ui.renderers;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.TextView;
 
 import com.pedrogomez.renderers.sample.R;
 import com.pedrogomez.renderers.sample.model.Video;

--- a/sample/src/main/java/com/pedrogomez/renderers/sample/ui/renderers/SelectableVideoRenderer.java
+++ b/sample/src/main/java/com/pedrogomez/renderers/sample/ui/renderers/SelectableVideoRenderer.java
@@ -40,6 +40,11 @@ public class SelectableVideoRenderer extends VideoRenderer {
     }
 
     @Override
+    protected String getItemId() {
+        return getContent().getId();
+    }
+
+    @Override
     public void render() {
         super.render();
         renderSelection(isSelected());

--- a/sample/src/main/java/com/pedrogomez/renderers/sample/ui/renderers/SelectableVideoRenderer.java
+++ b/sample/src/main/java/com/pedrogomez/renderers/sample/ui/renderers/SelectableVideoRenderer.java
@@ -1,0 +1,75 @@
+package com.pedrogomez.renderers.sample.ui.renderers;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import com.pedrogomez.renderers.sample.R;
+import com.pedrogomez.renderers.sample.model.Video;
+
+import butterknife.Bind;
+import butterknife.ButterKnife;
+import butterknife.OnClick;
+import butterknife.OnLongClick;
+
+import static android.view.View.INVISIBLE;
+import static android.view.View.VISIBLE;
+
+public class SelectableVideoRenderer extends VideoRenderer {
+
+    @Bind(R.id.v_selection) View selection;
+
+    private Listener removeItemListener;
+
+    public interface Listener {
+
+        void onLongPressClicked(SelectableVideoRenderer renderer);
+
+        void onRemoveButtonTapped(Video video);
+    }
+
+    public SelectableVideoRenderer(Listener removeItemListener) {
+        this.removeItemListener = removeItemListener;
+    }
+
+    @Override protected View inflate(LayoutInflater inflater, ViewGroup parent) {
+        View inflatedView = inflater.inflate(R.layout.selectable_video_renderer, parent, false);
+        ButterKnife.bind(this, inflatedView);
+        return inflatedView;
+    }
+
+    @Override
+    public void render() {
+        super.render();
+        renderSelection(isSelected());
+    }
+
+    @Override protected void renderLabel() {
+        String deleteLabel = getContext().getString(R.string.delete_label);
+        getLabel().setText(deleteLabel);
+    }
+
+    @Override protected void renderMarker(Video video) {
+
+    }
+
+    @OnClick(R.id.iv_thumbnail) void onVideoClicked() {
+        toggleSelection();
+    }
+
+    @OnClick(R.id.tv_label) void clickOnDelete() {
+        setSelected(false);
+        removeItemListener.onRemoveButtonTapped(getContent());
+    }
+
+    @OnLongClick(R.id.iv_thumbnail) boolean longClickOnItem() {
+        setSelected(true);
+        removeItemListener.onLongPressClicked(this);
+        return true;
+    }
+
+    private void renderSelection(boolean isSelected) {
+        selection.setVisibility(isSelected ? VISIBLE : INVISIBLE);
+    }
+}

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -37,6 +37,12 @@
       android:layout_height="wrap_content"
       android:text="@string/open_rv_sample"/>
 
+  <Button
+      android:id="@+id/bt_open_multiselect_rv_sample"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:text="@string/open_multiselect_rv_sample"/>
+
   </LinearLayout>
 
 </RelativeLayout>

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -43,6 +43,12 @@
       android:layout_height="wrap_content"
       android:text="@string/open_multiselect_rv_sample"/>
 
+  <Button
+      android:id="@+id/bt_open_singleselect_rv_sample"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:text="@string/open_singleselect_rv_sample"/>
+
   </LinearLayout>
 
 </RelativeLayout>

--- a/sample/src/main/res/layout/selectable_video_renderer.xml
+++ b/sample/src/main/res/layout/selectable_video_renderer.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2014 Pedro Vicente Gomez Sanchez.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    style="@style/AppTheme.Video">
+
+  <ImageView
+      android:id="@+id/iv_thumbnail"
+      style="@style/AppTheme.Video.Thumbnail"/>
+
+  <View
+      android:id="@+id/v_selection"
+      android:layout_alignLeft="@+id/iv_thumbnail"
+      android:layout_alignRight="@+id/iv_thumbnail"
+      android:layout_alignTop="@+id/iv_thumbnail"
+      android:layout_alignBottom="@+id/iv_thumbnail"
+      style="@style/AppTheme.Video.ThumbnailSelector"/>
+
+  <ImageView
+      android:id="@+id/iv_play"
+      style="@style/AppTheme.Video.Play"/>
+
+  <ImageView
+      android:id="@+id/iv_marker"
+      style="@style/AppTheme.Video.Marker"/>
+
+  <TextView
+      android:id="@+id/tv_label"
+      style="@style/AppTheme.Video.Label"/>
+
+  <TextView
+      android:id="@+id/tv_title"
+      style="@style/AppTheme.Video.Title"/>
+
+</RelativeLayout>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -25,5 +25,6 @@
   <string name="open_lv_sample">Open ListView sample</string>
   <string name="open_rv_sample">Open RecyclerView sample</string>
   <string name="open_multiselect_rv_sample">Open Multi-selection RecyclerView sample</string>
+  <string name="open_singleselect_rv_sample">Open Single-selection RecyclerView sample</string>
 
 </resources>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -24,5 +24,6 @@
   <string name="delete_label">Delete me</string>
   <string name="open_lv_sample">Open ListView sample</string>
   <string name="open_rv_sample">Open RecyclerView sample</string>
+  <string name="open_multiselect_rv_sample">Open Multi-selection RecyclerView sample</string>
 
 </resources>

--- a/sample/src/main/res/values/styles.xml
+++ b/sample/src/main/res/values/styles.xml
@@ -16,7 +16,7 @@
   -->
 <resources>
 
-  <style name="AppTheme" parent="android:Theme.Holo.Light.DarkActionBar">
+  <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
 
   </style>
 
@@ -41,11 +41,23 @@
     <item name="android:layout_width">fill_parent</item>
   </style>
 
+  <style name="AppTheme.Video.ThumbnailContainer">
+    <item name="android:layout_height">wrap_content</item>
+    <item name="android:layout_width">wrap_content</item>
+    <item name="android:foreground">?attr/selectableItemBackground</item>
+    <item name="android:clickable">true</item>
+    <item name="android:focusable">true</item>
+  </style>
+
   <style name="AppTheme.Video.Thumbnail">
     <item name="android:layout_height">fill_parent</item>
     <item name="android:src">@drawable/placeholder</item>
     <item name="android:layout_centerVertical">true</item>
     <item name="android:scaleType">centerCrop</item>
+  </style>
+
+  <style name="AppTheme.Video.ThumbnailSelector">
+    <item name="android:background">#88FF0000</item>
   </style>
 
   <style name="AppTheme.Video.Play">


### PR DESCRIPTION
Hi @pedrovgs!

Issue #20 

I have to provide multi-selection in a `RecyclerView` implemented using Renderers. It was too hard to provide it without modifying your lib so I ended making the needed changes directly. I hope you like them.

I wanted a simple implementation trying to do not modify the current API which is probably used by a lot of projects.

`RVAdapter` can be instanced passing a SelectionMode now:

- `NONE` for disabling multiselection
- `SINGLE` for single selection 
- `MULTI` for multi-selecting

`RVAdapter` will create a `Selector` object based on this enum internally. The `Selector` manages the logic about keeping the selecting state. There are 3 implementations:

- `NoneSelector`. Empty implementation for those users which won't use the new multi-selection feature
- `MultiSelector`. Implementation for multi-selection. It tracks the item selected and also the renderers used in order to refresh them when it's necessary (i.e. when the selection mode is finished). The item selection tracking is done using a new method added to the renderer which provides a unique id from the content represented by the renderers. The default implementation is using `content.hashcode()` which will be fine for most projects but anyone can override this method and customize it if it's needed.
Why using IDs instead of Positions? Because positions are not fixed, they change when dispatching inserts, removes or deletions to the Adapter or when using `DiffUtil` obviously.
- `SingleSelector`. Implementation for single selection. It's based on `MultiSelector` but deselecting previously selected items when a new selection is performed.

Several methods have been added to `Renderer` in order to provide an API to select the item represented by the `Renderer` or not. I've tried to simplify this API as possible because it will be used only in the RecyclerView renderer implementation.
Before selecting, the adapter should be changed to selectable state or the selection won't work. Why this? Because we will want to perform different actions when the adapter is in selection mode or not, for example, we would want to open a photo when the adapter is not selectable or change the renderer selection state when the adapter is selectable.

I've also added a couple of examples where you can see the feature working directly.

If you have any question or you don't like the approach, please, feel free to comment it.


