### PR TITLE
Enable depedency caching for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: android
 
+cache:
+  directories:
+    - $HOME/.gradle
+
 android:
   components:
     - tools


### PR DESCRIPTION
Would be interested to know why gradle dependencies haven't been cached on Travis. Thank you.
